### PR TITLE
Normalize all encoding to explicit utf-8.

### DIFF
--- a/src/dynamodb_encryption_sdk/internal/crypto/authentication.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/authentication.py
@@ -18,7 +18,7 @@ from dynamodb_encryption_sdk.delegated_keys import DelegatedKey
 from dynamodb_encryption_sdk.encrypted import CryptoConfig
 from dynamodb_encryption_sdk.identifiers import ItemAction
 from dynamodb_encryption_sdk.internal.formatting.serialize.attribute import serialize_attribute
-from dynamodb_encryption_sdk.internal.identifiers import SignatureValues, Tag
+from dynamodb_encryption_sdk.internal.identifiers import SignatureValues, Tag, TEXT_ENCODING
 from dynamodb_encryption_sdk.structures import AttributeActions
 
 __all__ = ('sign_item', 'verify_item_signature')
@@ -85,7 +85,7 @@ def _string_to_sign(item, table_name, attribute_actions):
     data_to_sign = bytearray()
     data_to_sign.extend(_hash_data(
         hasher=hasher,
-        data='TABLE>{}<TABLE'.format(table_name).encode('utf-8')
+        data='TABLE>{}<TABLE'.format(table_name).encode(TEXT_ENCODING)
     ))
     for key in sorted(item.keys()):
         action = attribute_actions.action(key)
@@ -94,7 +94,7 @@ def _string_to_sign(item, table_name, attribute_actions):
 
         data_to_sign.extend(_hash_data(
             hasher=hasher,
-            data=key.encode('utf-8')
+            data=key.encode(TEXT_ENCODING)
         ))
 
         if action is ItemAction.SIGN_ONLY:

--- a/src/dynamodb_encryption_sdk/internal/formatting/deserialize/attribute.py
+++ b/src/dynamodb_encryption_sdk/internal/formatting/deserialize/attribute.py
@@ -29,7 +29,7 @@ from boto3.dynamodb.types import Binary
 from dynamodb_encryption_sdk.exceptions import DeserializationError
 from dynamodb_encryption_sdk.internal.defaults import LOGGING_NAME
 from dynamodb_encryption_sdk.internal.formatting.deserialize import decode_byte, decode_length, decode_tag, decode_value
-from dynamodb_encryption_sdk.internal.identifiers import Tag, TagValues
+from dynamodb_encryption_sdk.internal.identifiers import Tag, TagValues, TEXT_ENCODING
 from dynamodb_encryption_sdk.internal.str_ops import to_str
 
 __all__ = ('deserialize_attribute',)
@@ -69,7 +69,7 @@ def deserialize_attribute(serialized_attribute):  # noqa: C901 pylint: disable=t
         :param bytes value: Raw deserialized value
         :rtype: dynamodb_encryption_sdk.internal.dynamodb_types.STRING
         """
-        return codecs.decode(value, 'utf-8')
+        return codecs.decode(value, TEXT_ENCODING)
 
     def _deserialize_string(stream):
         # type: (io.BytesIO) -> Dict[str, dynamodb_types.STRING]
@@ -89,7 +89,7 @@ def deserialize_attribute(serialized_attribute):  # noqa: C901 pylint: disable=t
         :param bytes value: Raw deserialized value
         :rtype: dynamodb_encryption_sdk.internal.dynamodb_types.STRING
         """
-        raw_value = codecs.decode(value, 'utf-8')
+        raw_value = codecs.decode(value, TEXT_ENCODING)
         decimal_value = Decimal(to_str(raw_value))
         return str(decimal_value.normalize())
 

--- a/src/dynamodb_encryption_sdk/internal/identifiers.py
+++ b/src/dynamodb_encryption_sdk/internal/identifiers.py
@@ -19,6 +19,10 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
+#: Encoding to use for all text values.
+#: This is noted here for consistency but should not be changed.
+TEXT_ENCODING = 'utf-8'
+
 
 class ReservedAttributes(Enum):
     """Item attributes reserved for use by DynamoDBEncryptionClient"""

--- a/src/dynamodb_encryption_sdk/internal/str_ops.py
+++ b/src/dynamodb_encryption_sdk/internal/str_ops.py
@@ -15,6 +15,8 @@ import codecs
 
 import six
 
+from dynamodb_encryption_sdk.internal.identifiers import TEXT_ENCODING
+
 
 def to_str(data):
     """Takes an input str or bytes object and returns an equivalent str object.
@@ -25,7 +27,7 @@ def to_str(data):
     :rtype: str
     """
     if isinstance(data, bytes):
-        return codecs.decode(data, 'utf-8')
+        return codecs.decode(data, TEXT_ENCODING)
     return data
 
 
@@ -38,5 +40,5 @@ def to_bytes(data):
     :rtype: bytes
     """
     if isinstance(data, six.string_types) and not isinstance(data, bytes):
-        return codecs.encode(data, 'utf-8')
+        return codecs.encode(data, TEXT_ENCODING)
     return data

--- a/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
+++ b/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
@@ -29,7 +29,7 @@ from dynamodb_encryption_sdk.delegated_keys.jce import JceNameLocalDelegatedKey
 from dynamodb_encryption_sdk.exceptions import UnknownRegionError, UnwrappingError, WrappingError
 from dynamodb_encryption_sdk.identifiers import EncryptionKeyTypes, KeyEncodingType
 from dynamodb_encryption_sdk.internal import dynamodb_types
-from dynamodb_encryption_sdk.internal.identifiers import MaterialDescriptionKeys
+from dynamodb_encryption_sdk.internal.identifiers import MaterialDescriptionKeys, TEXT_ENCODING
 from dynamodb_encryption_sdk.internal.str_ops import to_bytes, to_str
 from dynamodb_encryption_sdk.internal.validators import dictionary_validator, iterable_validator
 from dynamodb_encryption_sdk.materials.raw import RawDecryptionMaterials, RawEncryptionMaterials
@@ -219,7 +219,7 @@ class AwsKmsCryptographicMaterialsProvider(CryptographicMaterialsProvider):
         """
         attribute_type, attribute_value = list(attribute.items())[0]
         if attribute_type == 'B':
-            return base64.b64encode(attribute_value.value).decode('utf-8')
+            return base64.b64encode(attribute_value.value).decode(TEXT_ENCODING)
         if attribute_type == 'S':
             return attribute_value
         raise ValueError('Attribute of type "{}" cannot be used in KMS encryption context.'.format(attribute_type))


### PR DESCRIPTION
The original idea was to have the encoding type centrally defined,
but we need to stick to utf-8 for compatibility anyway, so I think
it is simpler to just explicitly state it where it is needed.