### PR TITLE
fix behavior of AttributeActions when informed of indexed attributes that already have override instructions

### DIFF
--- a/test/functional/test_structures.py
+++ b/test/functional/test_structures.py
@@ -13,7 +13,9 @@
 """"""
 import pytest
 
-from dynamodb_encryption_sdk.structures import TableIndex
+from dynamodb_encryption_sdk.exceptions import InvalidArgumentError
+from dynamodb_encryption_sdk.identifiers import ItemAction
+from dynamodb_encryption_sdk.structures import AttributeActions, TableIndex
 
 pytestmark = [pytest.mark.functional, pytest.mark.local]
 
@@ -56,3 +58,34 @@ def test_tableindex_from_key_schema(key_schema, expected_kwargs):
     expected_index = TableIndex(**expected_kwargs)
 
     assert index == expected_index
+
+
+@pytest.mark.parametrize('default, overrides, expected_result', (
+    (ItemAction.ENCRYPT_AND_SIGN, {}, ItemAction.SIGN_ONLY),
+    (ItemAction.SIGN_ONLY, {}, ItemAction.SIGN_ONLY),
+    (ItemAction.DO_NOTHING, {}, ItemAction.DO_NOTHING),
+    (ItemAction.ENCRYPT_AND_SIGN, {'indexed_attribute': ItemAction.SIGN_ONLY}, ItemAction.SIGN_ONLY),
+    (ItemAction.ENCRYPT_AND_SIGN, {'indexed_attribute': ItemAction.DO_NOTHING}, ItemAction.DO_NOTHING),
+    (ItemAction.SIGN_ONLY, {'indexed_attribute': ItemAction.SIGN_ONLY}, ItemAction.SIGN_ONLY),
+    (ItemAction.SIGN_ONLY, {'indexed_attribute': ItemAction.DO_NOTHING}, ItemAction.DO_NOTHING),
+    (ItemAction.DO_NOTHING, {'indexed_attribute': ItemAction.SIGN_ONLY}, ItemAction.SIGN_ONLY),
+    (ItemAction.DO_NOTHING, {'indexed_attribute': ItemAction.DO_NOTHING}, ItemAction.DO_NOTHING)
+))
+def test_attribute_actions_index_override(default, overrides, expected_result):
+    test = AttributeActions(default_action=default, attribute_actions=overrides)
+    test.set_index_keys('indexed_attribute')
+
+    assert test.action('indexed_attribute') is expected_result
+
+
+@pytest.mark.parametrize('default', ItemAction)
+def test_attribute_actions_index_override_fail(default):
+    test = AttributeActions(
+        default_action=default,
+        attribute_actions={'indexed_attribute': ItemAction.ENCRYPT_AND_SIGN}
+    )
+
+    with pytest.raises(InvalidArgumentError) as excinfo:
+        test.set_index_keys('indexed_attribute')
+
+    excinfo.match(r'Cannot overwrite a previously requested action on indexed attribute: *')


### PR DESCRIPTION
Force AttributeActions.set_indexed_keys to fail if a different action was previously requested for any attributes being identified as indexed.