### PR TITLE
Remove the "hash=False" qualifier in attr.s setup.

### DIFF
--- a/src/dynamodb_encryption_sdk/delegated_keys/jce.py
+++ b/src/dynamodb_encryption_sdk/delegated_keys/jce.py
@@ -65,7 +65,7 @@ _ALGORITHM_GENERATE_MAP = {
 }
 
 
-@attr.s(hash=False)
+@attr.s
 class JceNameLocalDelegatedKey(DelegatedKey):
     """Delegated key that uses JCE StandardName algorithm values to determine behavior.
 

--- a/src/dynamodb_encryption_sdk/encrypted/__init__.py
+++ b/src/dynamodb_encryption_sdk/encrypted/__init__.py
@@ -22,7 +22,7 @@ from dynamodb_encryption_sdk.structures import AttributeActions, EncryptionConte
 __all__ = ('CryptoConfig',)
 
 
-@attr.s(hash=False)
+@attr.s
 class CryptoConfig(object):
     """Container for all configuration needed to encrypt or decrypt an item.
 

--- a/src/dynamodb_encryption_sdk/encrypted/client.py
+++ b/src/dynamodb_encryption_sdk/encrypted/client.py
@@ -23,7 +23,7 @@ from dynamodb_encryption_sdk.structures import AttributeActions, EncryptionConte
 __all__ = ('EncryptedClient',)
 
 
-@attr.s(hash=False)
+@attr.s
 class EncryptedClient(object):
     """High-level helper class to provide a familiar interface to encrypted tables.
 

--- a/src/dynamodb_encryption_sdk/encrypted/resource.py
+++ b/src/dynamodb_encryption_sdk/encrypted/resource.py
@@ -25,7 +25,7 @@ from dynamodb_encryption_sdk.structures import AttributeActions, EncryptionConte
 __all__ = ('EncryptedResource',)
 
 
-@attr.s(hash=False)
+@attr.s
 class EncryptedTablesCollectionManager(object):
     """Tables collection manager that provides EncryptedTable objects.
 
@@ -100,7 +100,7 @@ class EncryptedTablesCollectionManager(object):
         return self._transform_table(self._collection.page_size, **kwargs)
 
 
-@attr.s(hash=False)
+@attr.s
 class EncryptedResource(object):
     """High-level helper class to provide a familiar interface to encrypted tables.
 

--- a/src/dynamodb_encryption_sdk/encrypted/table.py
+++ b/src/dynamodb_encryption_sdk/encrypted/table.py
@@ -22,7 +22,7 @@ from dynamodb_encryption_sdk.structures import AttributeActions, EncryptionConte
 __all__ = ('EncryptedTable',)
 
 
-@attr.s(hash=False)
+@attr.s
 class EncryptedTable(object):
     """High-level helper class to provide a familiar interface to encrypted tables.
 

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/authentication.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/authentication.py
@@ -46,7 +46,7 @@ class JavaAuthenticator(object):
         """"""
 
 
-@attr.s(hash=False)
+@attr.s
 class JavaMac(JavaAuthenticator):
     """Symmetric MAC authenticators.
 
@@ -108,7 +108,7 @@ class JavaMac(JavaAuthenticator):
         verifier.verify(signature)
 
 
-@attr.s(hash=False)
+@attr.s
 class JavaSignature(JavaAuthenticator):
     """Asymmetric signature authenticators.
 

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/encryption.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/encryption.py
@@ -21,7 +21,7 @@ from dynamodb_encryption_sdk.exceptions import JceTransformationError
 __all__ = ('JavaCipher',)
 
 
-@attr.s(hash=False)
+@attr.s
 class JavaCipher(object):
     """Defines the encryption cipher, mode, and padding type to use for encryption.
 

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/primitives.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/primitives.py
@@ -87,7 +87,7 @@ class JavaPadding(object):
         """Build an instance of this padding type."""
 
 
-@attr.s(hash=False)
+@attr.s
 class SimplePadding(JavaPadding):
     """Padding types that do not require any preparation."""
     java_name = attr.ib(validator=attr.validators.instance_of(six.string_types))
@@ -103,7 +103,7 @@ class SimplePadding(JavaPadding):
         return self.padding()
 
 
-@attr.s(hash=False)
+@attr.s
 class BlockSizePadding(JavaPadding):
     """Padding types that require a block size input."""
     java_name = attr.ib(validator=attr.validators.instance_of(six.string_types))
@@ -119,7 +119,7 @@ class BlockSizePadding(JavaPadding):
         return self.padding(block_size)
 
 
-@attr.s(hash=False)
+@attr.s
 class OaepPadding(JavaPadding):
     """OAEP padding types. These require more complex setup.
 
@@ -149,7 +149,7 @@ class OaepPadding(JavaPadding):
         )
 
 
-@attr.s(hash=False)
+@attr.s
 class JavaMode(object):
     """Bridge the gap from the Java encryption mode names and Python resources.
         https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#Cipher
@@ -167,7 +167,7 @@ class JavaMode(object):
         return self.mode(iv)
 
 
-@attr.s(hash=False)
+@attr.s
 class JavaEncryptionAlgorithm(object):
     """Bridge the gap from the Java encryption algorithm names and Python resources.
     https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#Cipher

--- a/src/dynamodb_encryption_sdk/internal/utils.py
+++ b/src/dynamodb_encryption_sdk/internal/utils.py
@@ -35,7 +35,7 @@ def sorted_key_map(item, transform=to_bytes):
     return sorted_items
 
 
-@attr.s(hash=False)
+@attr.s
 class TableInfoCache(object):
     """Very simple cache of TableInfo objects, providing configuration information about DynamoDB tables.
 

--- a/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
+++ b/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
@@ -60,7 +60,7 @@ class EncryptionContextKeys(Enum):
     TABLE_NAME = '*aws-kms-table*'
 
 
-@attr.s(hash=False)
+@attr.s
 class KeyInfo(object):
     """Identifying information for a specific key and how it should be used.
 
@@ -94,7 +94,7 @@ class KeyInfo(object):
         return cls(description, algorithm, key_length)
 
 
-@attr.s(hash=False)
+@attr.s
 class AwsKmsCryptographicMaterialsProvider(CryptographicMaterialsProvider):
     """Cryptographic materials provider for use with the AWS Key Management Service (KMS).
 

--- a/src/dynamodb_encryption_sdk/material_providers/static.py
+++ b/src/dynamodb_encryption_sdk/material_providers/static.py
@@ -20,7 +20,7 @@ from dynamodb_encryption_sdk.structures import EncryptionContext
 __all__ = ('StaticCryptographicMaterialsProvider',)
 
 
-@attr.s(hash=False)
+@attr.s
 class StaticCryptographicMaterialsProvider(CryptographicMaterialsProvider):
     """Manually combine encryption and decryption materials for use as a cryptographic materials provider.
 

--- a/src/dynamodb_encryption_sdk/material_providers/wrapped.py
+++ b/src/dynamodb_encryption_sdk/material_providers/wrapped.py
@@ -22,7 +22,7 @@ from dynamodb_encryption_sdk.structures import EncryptionContext
 __all__ = ('WrappedCryptographicMaterialsProvider',)
 
 
-@attr.s(hash=False)
+@attr.s
 class WrappedCryptographicMaterialsProvider(CryptographicMaterialsProvider):
     """Cryptographic materials provider to use ephemeral content encryption keys wrapped by delegated keys.
 

--- a/src/dynamodb_encryption_sdk/materials/raw.py
+++ b/src/dynamodb_encryption_sdk/materials/raw.py
@@ -34,7 +34,7 @@ from dynamodb_encryption_sdk.materials import DecryptionMaterials, EncryptionMat
 __all__ = ('RawEncryptionMaterials', 'RawDecryptionMaterials')
 
 
-@attr.s(hash=False)
+@attr.s
 class RawEncryptionMaterials(EncryptionMaterials):
     """Encryption materials for use directly with delegated keys.
 
@@ -94,7 +94,7 @@ class RawEncryptionMaterials(EncryptionMaterials):
         return self._encryption_key
 
 
-@attr.s(hash=False)
+@attr.s
 class RawDecryptionMaterials(DecryptionMaterials):
     """Encryption materials for use directly with delegated keys.
 

--- a/src/dynamodb_encryption_sdk/materials/wrapped.py
+++ b/src/dynamodb_encryption_sdk/materials/wrapped.py
@@ -34,7 +34,7 @@ _WRAPPING_TRANSFORMATION = {
 }
 
 
-@attr.s(hash=False)
+@attr.s
 class WrappedCryptographicMaterials(CryptographicMaterials):
     """Encryption/decryption key is a content key stored in the material description, wrapped
     by the wrapping key.

--- a/src/dynamodb_encryption_sdk/structures.py
+++ b/src/dynamodb_encryption_sdk/structures.py
@@ -38,7 +38,7 @@ def _validate_attribute_values_are_ddb_items(instance, attribute, value):
             raise TypeError('"{}" values do not look like DynamoDB items'.format(attribute.name))
 
 
-@attr.s(hash=False)
+@attr.s
 class EncryptionContext(object):
     """Additional information about an encryption request.
 
@@ -74,7 +74,7 @@ class EncryptionContext(object):
     )
 
 
-@attr.s(hash=False)
+@attr.s
 class AttributeActions(object):
     """Configuration resource used to determine what action should be taken for a specific attribute.
 
@@ -157,7 +157,7 @@ class AttributeActions(object):
         )
 
 
-@attr.s(hash=False)
+@attr.s
 class TableIndex(object):
     """Describes a table index.
 
@@ -202,7 +202,7 @@ class TableIndex(object):
         )
 
 
-@attr.s(hash=False)
+@attr.s
 class TableInfo(object):
     """Description of a DynamoDB table.
 


### PR DESCRIPTION
This was present in order to maintain consistent behavior if the library
was used with attrs < 17.0, but we are now using features of attrs
that were introduced after 17.0. I think we can safely remove these
safety barriers to get simpler, cleaner looking code.