### PR TITLE
add wrapped-aes-hmac encrypted item test vectors

### DIFF
--- a/test/vectors/encrypted_item/ciphertext/wrapped-aes-hmac-1.json
+++ b/test/vectors/encrypted_item/ciphertext/wrapped-aes-hmac-1.json
@@ -1,0 +1,351 @@
+{
+    "HashKeyOnly": [
+        {
+            "hashKey": {
+                "S": "Bar"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAODNvNHkzTTB3UUFCRXl1UXN0SFVQUGF1NkpPMUhiNk1OWGxXQW5aWDhYdmFYTlUwNUluTFUxZz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "iZXCp3s7VEMYdf01YEWqMlXOBHv3+e8gKbECrPUW47I="
+            }
+        },
+        {
+            "hashKey": {
+                "S": "Baz"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAODlZdEVSWXVDT3A4MHlKVnJOYytYREFoaVN6UHdlRnNJQk1YRXMxSEQ2eGdvdmYveldabmMrQT09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "zh74eH/yJQFzkm5mq52iFAlSDpXAFe3ZP2nv7X/xY1w="
+            }
+        },
+        {
+            "hashKey": {
+                "S": "Foo"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOEw2YkExbWszYTZxek1YNUkyMkYyYzRvU0FmZ2VZdCtjQmtFYndDTzhYUzlkL0ZqV20wekpZUT09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "HR5P6kozMSqqs+rnDMaCiymH8++OwEVzx2Y13ZMp5P8="
+            }
+        }
+    ],
+    "TableName": [
+        {
+            "rangeKey": {
+                "N": "1"
+            },
+            "hashKey": {
+                "N": "1"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOEpKNDk2UGRpcDViOHlldTVxbEE0STNOUjFTVHdtZEd2REJwQWowNXprUmN0OFh6T3E1TmRJZz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "yT2ehLcx/a609Ez6laLkTAqCtp0IYzzKV8Amv8jdQMw="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "2"
+            },
+            "hashKey": {
+                "N": "1"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOHNVQzNEekp5Tk1tZ3ZUSE1EVnh2Sng1OCtDT1h0UStwRzR4ZlVQL0pJTkRHOGI1M00wOFRBZz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "YAai32/7MVrGjSzgcVxkFDqU+G9HcmuiNSWZHcnvfjg="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "3"
+            },
+            "hashKey": {
+                "N": "1"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOEZGdjVQNjAxZzF0eXhoaDhxQmlCdDB1d2JoODlRaDdyeTcxL2lJdWxvSWNvQzFBV3JHczhtdz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "0iwjbBLCdtSosmDTDYzKxu3Q5qda0Ok9q3VbIJczBV0="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "1"
+            },
+            "hashKey": {
+                "N": "5"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOHJ3OU5qdU53dkhENTZPTmlqWC9nbUlGZ051ZDk3OS94QXhlaTVjbmdJbmxhajdpSVg0RDdadz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "Gl1jMNLZl/B70Hz2B4K4K46kir+hE6AeX8azZfFi8GA="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "7"
+            },
+            "hashKey": {
+                "N": "5"
+            },
+            "stringValue": {
+                "B": "MyVrAzOuKFS+hAiVq0jlmIJcwMP2w62LdWChncBN0q0HMB3WpADYK2BF1q+oQP83"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOHlUK09JWlpaWkE5VmU0dTdwRE1zNG9TUVZTNlFYZEFmQjZkVjlMMUg4QzBrRXliQ0Nad0JRQT09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "intSet": {
+                "B": "0iLxGtvyDaUNXY1iYwcDlZX3zIs+QOMsBQ+RbX6YlAgFdMK/k57OXPH3jMIptzkNAKNWFea+NAz+AXFd2jPC8w=="
+            },
+            "doubleSet": {
+                "B": "0nazy+tnY85GZpSANJzBLXZHPKzCvN4ggpopjujfAOO37wDi6zrSwhurLpjFIJGR27pn5azaroZWYA8GLfiGIw=="
+            },
+            "byteArrayValue": {
+                "B": "w9sfXioZCE9luCt4qiOixyRJVlJ6zbTwFoFg0wQNJbA="
+            },
+            "stringSet": {
+                "B": "8057NGIAJADqX/KzkjZl7XzFMI/6j7vAbp5F83tZjOQhguhp8hheXAzcsrCmM6sME1oGEmJEran4Svs1qT5ChA=="
+            },
+            "intValue": {
+                "B": "LFHv7oLor2SoKypi/gubI0IsipoLd/I20qPr2wHOgOs="
+            },
+            "doubleValue": {
+                "B": "uq8MBbPKDskxhyJ6VCmd9EC6+tD3EuiqhgFUpxckzdk="
+            },
+            "version": {
+                "N": "1"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "FhpaX3jXqz+Pg4QETqcNBULC+OBOTkux2BFGCdnr5PY="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "1E+1"
+            },
+            "hashKey": {
+                "N": "8"
+            },
+            "stringValue": {
+                "S": "Hello world!"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAODRhOGRFc01ybDR6ODlVM1RkOWh4L0J2cms4cVZEODlOaklkMnU0d2NGSnBxbUVkc1lka2ZXZz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "intSet": {
+                "NS": [
+                    "0",
+                    "1",
+                    "15",
+                    "1E+1",
+                    "2E+2"
+                ]
+            },
+            "doubleSet": {
+                "NS": [
+                    "-3",
+                    "-34.2",
+                    "0",
+                    "15",
+                    "7.6"
+                ]
+            },
+            "byteArrayValue": {
+                "B": "AAECAwQF"
+            },
+            "stringSet": {
+                "SS": [
+                    "?",
+                    "Cruel",
+                    "Goodbye",
+                    "World"
+                ]
+            },
+            "intValue": {
+                "N": "123"
+            },
+            "doubleValue": {
+                "N": "15"
+            },
+            "version": {
+                "N": "1"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "5NHNzCBtZcVAUlz1ymLB7Ta+1n3VjffLj5WniFA9afo="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "3"
+            },
+            "hashKey": {
+                "N": "7"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOE55eTdqK3FkNEJMNzV2MTlnRHdHVHdtTGgrbmlMaER0cjdaL3ZZMVFmQTFEQmE5Y0JGdzIxdz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "cSTe0npOBBtsxSN4F9mLF2WTyCN1+1owsVoGkYumiZQ="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "9"
+            },
+            "hashKey": {
+                "N": "7"
+            },
+            "stringValue": {
+                "S": "Hello world!"
+            },
+            "intSet": {
+                "NS": [
+                    "0",
+                    "1",
+                    "15",
+                    "1E+1",
+                    "2E+2"
+                ]
+            },
+            "doubleSet": {
+                "NS": [
+                    "-3",
+                    "-34.2",
+                    "0",
+                    "15",
+                    "7.6"
+                ]
+            },
+            "byteArrayValue": {
+                "B": "AAECAwQF"
+            },
+            "stringSet": {
+                "SS": [
+                    "?",
+                    "Cruel",
+                    "Goodbye",
+                    "World"
+                ]
+            },
+            "intValue": {
+                "N": "123"
+            },
+            "doubleValue": {
+                "N": "15"
+            },
+            "version": {
+                "N": "1"
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "1"
+            },
+            "hashKey": {
+                "N": "0"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOGcrY1NpV2I3eWZYZ2pQS2gzOVM0anBZZWFNeEhHRG90c2JCOG5sQkp3ei9vclBRQzhOZFNxdz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "lBLoUXuc8TgsJJlItgBh6PJ1YVk52nvQE9aErEB8jK8="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "2"
+            },
+            "hashKey": {
+                "N": "0"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOHlKa2M4OW9HNEpoajhyazlEQnpVeEQ1cForN1Q4Z2pQUEU1TE9uVDhvd2tJWDJ6bGFpdUJKQT09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "cjd91WBBFWPnrJxIJ2p2hnXFVCemgYw0HqRWcnoQcq4="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "3"
+            },
+            "hashKey": {
+                "N": "0"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOG9kQ2hPVmtiYkN3S3V3VHYrVjYvelNwcnZIUWVhWlpqaDZvU3JzMHV4T255bFQzSUZ0TjVVZz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "uXZKvYmUgZEOunUJctXpkvqhrgUoK1eLi8JpvlRozTI="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "2"
+            },
+            "hashKey": {
+                "N": "6"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOEJLV0Z2T0hRVUxCMTcxTW56dkQrVVYyMVpmTUxhSXl4QjB3ekdZbStzY2VFd2pNekgxTFhVQT09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "66Vz0G8nOQzlvIpImXSkl+nmCpTYeRy8mAF4qgGgMw0="
+            }
+        },
+        {
+            "rangeKey": {
+                "N": "8"
+            },
+            "stringValue": {
+                "S": "Hello world!"
+            },
+            "hashKey": {
+                "N": "6"
+            },
+            "*amzn-ddb-map-desc*": {
+                "B": "AAAAAAAAABBhbXpuLWRkYi1lbnYta2V5AAAAOEdncWp2Q3JaYzhZL2RrMGxmQlk5K09tbWNXUWIvbjVYMW01YTNBcElZb3JLVzU0RVhRYTgrZz09AAAAEGFtem4tZGRiLWVudi1hbGcAAAADQUVTAAAAEWFtem4tZGRiLXdyYXAtYWxnAAAAB0FFU1dyYXAAAAAVYW16bi1kZGItbWFwLXN5bS1tb2RlAAAAES9DQkMvUEtDUzVQYWRkaW5n"
+            },
+            "doubleSet": {
+                "NS": [
+                    "-3",
+                    "-34.2",
+                    "0",
+                    "15",
+                    "7.6"
+                ]
+            },
+            "intSet": {
+                "B": "eBhcgBr8TocxVsTw8tJtcAK2VKFOkoZlWBUusFNtKbTulghzdpT3iTMqIJB86ViXXguO43XqMZWs1U3G/IaF+g=="
+            },
+            "byteArrayValue": {
+                "B": "Y3ciZfN54gf86a4mxRfon9CgzQkNIxrtWV8s6tg/6G0="
+            },
+            "intValue": {
+                "N": "123"
+            },
+            "stringSet": {
+                "B": "RhykbS8bqGEd2LEGtLV0S6Pj+4KjuVc15ExkUmlCKlClAgNpukA5Tp0FjU/XL0Qli4v6apZaraKgBC1l4YlRDg=="
+            },
+            "doubleValue": {
+                "N": "15"
+            },
+            "version": {
+                "N": "1"
+            },
+            "*amzn-ddb-map-sig*": {
+                "B": "mC10Qiw1c/P8Bab4SaP3kmsPMBVfOZKjZ3SgvXyd3Vg="
+            }
+        }
+    ]
+}

--- a/test/vectors/encrypted_item/scenarios.json
+++ b/test/vectors/encrypted_item/scenarios.json
@@ -61,6 +61,16 @@
             },
             "plaintext": "file://plaintext.json",
             "ciphertext": "file://ciphertext/wrapped-rsa-rsa-3.json"
+        },
+        {
+            "version": "v1",
+            "provider": "wrapped",
+            "keys": {
+                "decrypt": "aesKey",
+                "verify": "hmacKey"
+            },
+            "plaintext": "file://plaintext.json",
+            "ciphertext": "file://ciphertext/wrapped-aes-hmac-1.json"
         }
     ]
 }


### PR DESCRIPTION
More vectors that feed the acceptance tests.

Proof they work:
```
186590df9307:aws-dynamodb-encryption-python bullocm$ tox -e py36-local-fast test/acceptance/encrypted/test_item.py  -- -vv
GLOB sdist-make: /Users/bullocm/git/aws-dynamodb-encryption-python/setup.py
py36-local-fast inst-nodeps: /Users/bullocm/git/aws-dynamodb-encryption-python/.tox/dist/dynamodb-encryption-sdk-0.0.0.zip
py36-local-fast installed: apipkg==1.4,asn1crypto==0.24.0,attrs==17.4.0,aws-xray-sdk==0.95,boto==2.48.0,boto3==1.7.9,botocore==1.10.9,certifi==2018.4.16,cffi==1.11.5,chardet==3.0.4,cookies==2.2.1,coverage==4.5.1,cryptography==2.2.2,docker==3.3.0,docker-pycreds==0.2.3,docutils==0.14,dynamodb-encryption-sdk==0.0.0,execnet==1.5.0,hypothesis==3.56.5,idna==2.6,Jinja2==2.10,jmespath==0.9.3,jsondiff==1.1.1,jsonpickle==0.9.6,MarkupSafe==1.0,mock==2.0.0,more-itertools==4.1.0,moto==1.3.3,pbr==4.0.2,pluggy==0.6.0,py==1.5.3,pyaml==17.12.1,pycparser==2.18,pytest==3.5.1,pytest-cov==2.5.1,pytest-forked==0.2,pytest-mock==1.9.0,pytest-xdist==1.22.2,python-dateutil==2.7.2,pytz==2018.4,PyYAML==3.12,requests==2.18.4,responses==0.9.0,s3transfer==0.1.13,six==1.11.0,urllib3==1.22,websocket-client==0.47.0,Werkzeug==0.14.1,wrapt==1.10.11,xmltodict==0.11.0
py36-local-fast runtests: PYTHONHASHSEED='2473080594'
py36-local-fast runtests: commands[0] | pytest --basetemp=/Users/bullocm/git/aws-dynamodb-encryption-python/.tox/py36-local-fast/tmp -l --cov dynamodb_encryption_sdk test/acceptance/encrypted/test_item.py -vv -m local and not slow and not veryslow and not nope
============================================================================================ test session starts =============================================================================================
platform darwin -- Python 3.6.4, pytest-3.5.1, py-1.5.3, pluggy-0.6.0 -- /Users/bullocm/git/aws-dynamodb-encryption-python/.tox/py36-local-fast/bin/python3.6
cachedir: .pytest_cache
rootdir: /Users/bullocm/git/aws-dynamodb-encryption-python, inifile: setup.cfg
plugins: xdist-1.22.2, mock-1.9.0, forked-0.2, cov-2.5.1, hypothesis-3.56.5
collected 112 items                                                                                                                                                                                          

test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '1'}}0] PASSED                                                [  0%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '2'}}0] PASSED                                                [  1%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '3'}}0] PASSED                                                [  2%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '1'}}0] PASSED                                                [  3%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '2'}}0] PASSED                                                [  4%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '3'}}0] PASSED                                                [  5%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '1'}}0] PASSED                                                [  6%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '2'}}0] PASSED                                                [  7%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '3'}}0] PASSED                                                [  8%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '7'}}0] PASSED                                                [  8%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '8'}}0] PASSED                                                [  9%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '8'}, 'rangeKey': {'N': '1E+1'}}0] PASSED                                             [ 10%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '9'}}0] PASSED                                                [ 11%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Bar'}}0] PASSED                                                                    [ 12%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Baz'}}0] PASSED                                                                    [ 13%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Foo'}}0] PASSED                                                                    [ 14%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Bar'}}1] PASSED                                                                    [ 15%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Baz'}}1] PASSED                                                                    [ 16%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Foo'}}1] PASSED                                                                    [ 16%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '1'}}1] PASSED                                                [ 17%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '2'}}1] PASSED                                                [ 18%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '3'}}1] PASSED                                                [ 19%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '1'}}1] PASSED                                                [ 20%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '2'}}1] PASSED                                                [ 21%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '3'}}1] PASSED                                                [ 22%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '1'}}1] PASSED                                                [ 23%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '7'}}1] PASSED                                                [ 24%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '2'}}1] PASSED                                                [ 25%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '8'}}1] PASSED                                                [ 25%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '3'}}1] PASSED                                                [ 26%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '9'}}1] PASSED                                                [ 27%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '8'}, 'rangeKey': {'N': '1E+1'}}1] PASSED                                             [ 28%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '1'}}] PASSED                                                 [ 29%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '2'}}] PASSED                                                 [ 30%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '3'}}] PASSED                                                 [ 31%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '1'}}] PASSED                                                 [ 32%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '2'}}] PASSED                                                 [ 33%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '3'}}] PASSED                                                 [ 33%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '1'}}] PASSED                                                 [ 34%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '7'}}] PASSED                                                 [ 35%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '2'}}] PASSED                                                 [ 36%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '8'}}] PASSED                                                 [ 37%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '3'}}] PASSED                                                 [ 38%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '9'}}] PASSED                                                 [ 39%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-TableName-{'hashKey': {'N': '8'}, 'rangeKey': {'N': '1E+1'}}] PASSED                                              [ 40%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Bar'}}] PASSED                                                                     [ 41%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Baz'}}] PASSED                                                                     [ 41%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-static-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Foo'}}] PASSED                                                                     [ 42%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '1'}}0] PASSED                                         [ 43%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '2'}}0] PASSED                                         [ 44%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '3'}}0] PASSED                                         [ 45%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '1'}}0] PASSED                                         [ 46%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '2'}}0] PASSED                                         [ 47%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '3'}}0] PASSED                                         [ 48%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '1'}}0] PASSED                                         [ 49%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '7'}}0] PASSED                                         [ 50%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '2'}}0] PASSED                                         [ 50%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '8'}}0] PASSED                                         [ 51%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '3'}}0] PASSED                                         [ 52%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '9'}}0] PASSED                                         [ 53%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '8'}, 'rangeKey': {'N': '1E+1'}}0] PASSED                                      [ 54%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-HashKeyOnly-{'hashKey': {'S': 'Bar'}}0] PASSED                                                             [ 55%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-HashKeyOnly-{'hashKey': {'S': 'Baz'}}0] PASSED                                                             [ 56%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-HashKeyOnly-{'hashKey': {'S': 'Foo'}}0] PASSED                                                             [ 57%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '1'}}] PASSED                                          [ 58%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '2'}}] PASSED                                          [ 58%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '3'}}] PASSED                                          [ 59%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '1'}}] PASSED                                          [ 60%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '2'}}] PASSED                                          [ 61%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '3'}}] PASSED                                          [ 62%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '1'}}] PASSED                                          [ 63%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '7'}}] PASSED                                          [ 64%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '2'}}] PASSED                                          [ 65%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '8'}}] PASSED                                          [ 66%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '3'}}] PASSED                                          [ 66%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '9'}}] PASSED                                          [ 67%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '8'}, 'rangeKey': {'N': '1E+1'}}] PASSED                                       [ 68%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-HashKeyOnly-{'hashKey': {'S': 'Bar'}}] PASSED                                                              [ 69%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-HashKeyOnly-{'hashKey': {'S': 'Baz'}}] PASSED                                                              [ 70%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-rsaEncPriv-rsaEncPub-HashKeyOnly-{'hashKey': {'S': 'Foo'}}] PASSED                                                              [ 71%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-HashKeyOnly-{'hashKey': {'S': 'Bar'}}1] PASSED                                                             [ 72%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-HashKeyOnly-{'hashKey': {'S': 'Baz'}}1] PASSED                                                             [ 73%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-HashKeyOnly-{'hashKey': {'S': 'Foo'}}1] PASSED                                                             [ 74%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '1'}}1] PASSED                                         [ 75%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '2'}}1] PASSED                                         [ 75%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '3'}}1] PASSED                                         [ 76%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '1'}}1] PASSED                                         [ 77%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '2'}}1] PASSED                                         [ 78%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '3'}}1] PASSED                                         [ 79%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '1'}}1] PASSED                                         [ 80%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '7'}}1] PASSED                                         [ 81%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '2'}}1] PASSED                                         [ 82%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '8'}}1] PASSED                                         [ 83%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '3'}}1] PASSED                                         [ 83%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '9'}}1] PASSED                                         [ 84%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v0-wrapped-rsaEncPriv-rsaEncPub-TableName-{'hashKey': {'N': '8'}, 'rangeKey': {'N': '1E+1'}}1] PASSED                                      [ 85%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Bar'}}] PASSED                                                                    [ 86%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Baz'}}] PASSED                                                                    [ 87%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-HashKeyOnly-{'hashKey': {'S': 'Foo'}}] PASSED                                                                    [ 88%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '1'}}] PASSED                                                [ 89%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '2'}}] PASSED                                                [ 90%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '1'}, 'rangeKey': {'N': '3'}}] PASSED                                                [ 91%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '1'}}] PASSED                                                [ 91%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '5'}, 'rangeKey': {'N': '7'}}] PASSED                                                [ 92%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '8'}, 'rangeKey': {'N': '1E+1'}}] PASSED                                             [ 93%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '3'}}] PASSED                                                [ 94%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '7'}, 'rangeKey': {'N': '9'}}] PASSED                                                [ 95%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '1'}}] PASSED                                                [ 96%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '2'}}] PASSED                                                [ 97%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '0'}, 'rangeKey': {'N': '3'}}] PASSED                                                [ 98%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '2'}}] PASSED                                                [ 99%]
test/acceptance/encrypted/test_item.py::test_item_encryptor[v1-wrapped-aesKey-hmacKey-TableName-{'hashKey': {'N': '6'}, 'rangeKey': {'N': '8'}}] PASSED                                                [100%]

---------- coverage: platform darwin, python 3.6.4-final-0 -----------
Name                                                                                                                    Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/__init__.py                                        3      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/delegated_keys/__init__.py                        29      9      2      0    71%   50, 61, 75, 89, 102, 118, 129, 139, 151
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/delegated_keys/jce.py                             94     26      8      1    70%   39, 49-59, 129-130, 136, 149-161, 187-188, 215-216, 235, 258-259, 282, 234->235
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/encrypted/__init__.py                             32      8     16      3    65%   44, 48, 64, 84-89, 42->46, 43->44, 47->48
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/encrypted/client.py                               75     75     26      0     0%   13-204
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/encrypted/item.py                                 76     36     18      0    51%   50-101, 118-120, 146-149, 155-157, 202-204
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/encrypted/resource.py                             73     73     24      0     0%   13-250
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/encrypted/table.py                                54     54     12      0     0%   13-169
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/exceptions.py                                     19      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/identifiers.py                                    22      2      0      0    91%   28, 34
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/__init__.py                               1      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/crypto/__init__.py                        1      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/crypto/authentication.py                 34      2      6      0    95%   39-47
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/crypto/encryption.py                     17      4      0      0    76%   16, 41-47
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/crypto/jce_bridge/__init__.py             1      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/crypto/jce_bridge/authentication.py      57     11     14      1    75%   78-79, 95-97, 129-130, 143-146, 155, 154->155
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/crypto/jce_bridge/encryption.py          41      8     12      1    79%   46, 66-68, 101, 117-118, 144, 143->144
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/crypto/jce_bridge/primitives.py         163     61     34      6    62%   52, 60, 68, 76, 181-182, 197, 201, 206-207, 212-213, 226, 232, 248-260, 272, 280-283, 297-314, 343-346, 365-366, 397, 403, 422-431, 446, 449-452, 225->226, 231->232, 271->272, 396->397, 402->403, 445->446
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/defaults.py                               4      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/dynamodb_types.py                        14      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/formatting/__init__.py                    1      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/formatting/deserialize/__init__.py       22      3      2      1    83%   67-68, 82, 81->82
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/formatting/deserialize/attribute.py      81     21     12      2    69%   51, 120-121, 131, 155, 185-186, 199-211, 235-236, 249-250, 253, 50->51, 252->253
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/formatting/material_description.py       51     21      7      1    57%   37-50, 67-70, 80-83, 98-101, 103, 102->103
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/formatting/serialize/__init__.py          9      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/formatting/serialize/attribute.py        85     25     14      3    68%   56, 122-123, 133, 164, 191-198, 207-221, 240-241, 244, 247, 55->56, 243->244, 246->247
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/formatting/transform.py                  11      4      4      0    47%   34-35, 51-52
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/identifiers.py                           42      0      0      0   100%
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/str_ops.py                               13      1      4      1    88%   46, 44->46
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/utils.py                                 27     15      8      0    40%   30-35, 51, 61-68
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/internal/validators.py                            20      8     14      3    50%   29, 33, 39, 56-64, 28->29, 32->33, 38->39
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/material_providers/__init__.py                    10      2      0      0    80%   31, 41
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/material_providers/aws_kms.py                    145    145     24      0     0%   13-435
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/material_providers/static.py                      18      4      6      1    71%   50, 62-65, 49->50
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/material_providers/wrapped.py                     23      4      6      1    76%   81-84, 97, 96->97
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/materials/__init__.py                             24      4      2      0    85%   88, 96, 108, 116
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/materials/raw.py                                  36      7      8      1    77%   61-62, 74, 84, 94, 122, 134, 121->122
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/materials/wrapped.py                              61     19      8      2    67%   85, 94, 103, 130-158, 177, 195, 82->85, 102->103
.tox/py36-local-fast/lib/python3.6/site-packages/dynamodb_encryption_sdk/structures.py                                     91     35     38      4    56%   37-38, 99, 138, 149-154, 175-177, 195-199, 235-237, 248-250, 255, 264-270, 278-287, 36->37, 98->99, 137->134, 137->138
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                                    1580    687    329     32    53%


========================================================================================= 112 passed in 1.47 seconds =========================================================================================
__________________________________________________________________________________________________ summary ___________________________________________________________________________________________________
  py36-local-fast: commands succeeded
  congratulations :)

```