### PR TITLE
fix hypothesis decimal strategy to fully filter out values that are not compatible with DYNAMODB_CONTEXT

### DIFF
--- a/test/functional/hypothesis_strategies.py
+++ b/test/functional/hypothesis_strategies.py
@@ -51,6 +51,15 @@ NEGATIVE_NUMBER_RANGE = NumberRange(
 )
 
 
+def _valid_ddb_number(value):
+    try:
+        DYNAMODB_CONTEXT.create_decimal(float(value))
+    except Exception:
+        return False
+    else:
+        return True
+
+
 ddb_string = text(
     min_size=1,
     max_size=MAX_ITEM_BYTES
@@ -60,17 +69,17 @@ ddb_string_set = sets(ddb_string, min_size=1)
 
 def _ddb_fraction_to_decimal(val):
     """Hypothesis does not support providing a custom Context, so working around that."""
-    return DYNAMODB_CONTEXT.create_decimal(Decimal(val.numerator) / Decimal(val.denominator))
+    return Decimal(val.numerator) / Decimal(val.denominator)
 
 
 _ddb_positive_numbers = fractions(
     min_value=POSITIVE_NUMBER_RANGE.min,
     max_value=POSITIVE_NUMBER_RANGE.max
-).map(_ddb_fraction_to_decimal)
+).map(_ddb_fraction_to_decimal).filter(_valid_ddb_number)
 _ddb_negative_numbers = fractions(
     min_value=NEGATIVE_NUMBER_RANGE.min,
     max_value=NEGATIVE_NUMBER_RANGE.max
-).map(_ddb_fraction_to_decimal)
+).map(_ddb_fraction_to_decimal).filter(_valid_ddb_number)
 
 ddb_number = _ddb_negative_numbers | just(Decimal('0')) | _ddb_positive_numbers
 ddb_number_set = sets(ddb_number, min_size=1)


### PR DESCRIPTION
fix hypothesis decimal strategy to fully filter out values that are not compatible with DYNAMODB_CONTEXT

This fixes an earlier misconception I had about when the decimal context is checked: it is checked when decimals are created (ex: `.create_decimal()`), not when they operated on (ex: division).

**BLOCKED BY #21 and #22**

## NOTE

To ease parallelization of efforts, this PR is based on the `DELETE-4` fork. Prior to looking over this PR, #21 and #22 should be merged to `master` and the base for this PR be changed to `master`.