### PR TITLE
reverse processing order of KMS CMP client retrieval to properly select region

### DIFF
--- a/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
+++ b/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
@@ -197,18 +197,17 @@ class AwsKmsCryptographicMaterialsProvider(CryptographicMaterialsProvider):
         :returns: Boto3 KMS client for requested key id
         :rtype: botocore.client.KMS
         """
-        region = self._botocore_session.get_config_variable('region')
-        if region is None:
-            try:
-                region_name = key_id.split(':', 4)[3]
-                region = region_name
-            except IndexError:
-                if region is None:
-                    raise UnknownRegionError(
-                        'No default region found and no region determinable from key id: {}'.format(key_id)
-                    )
-        self._add_regional_client(region)
-        return self._regional_clients[region]
+        try:
+            key_region = key_id.split(':', 4)[3]
+            region = key_region
+        except IndexError:
+            session_region = self._botocore_session.get_config_variable('region')
+            if session_region is None:
+                raise UnknownRegionError(
+                    'No region determinable from key id: {} and no default region found in session'.format(key_id)
+                )
+            region = session_region
+        return self._add_regional_client(region)
 
     def _select_key_id(self, encryption_context):
         # type: (EncryptionContext) -> Text

--- a/test/unit/material_providers/test_aws_kms.py
+++ b/test/unit/material_providers/test_aws_kms.py
@@ -274,6 +274,28 @@ def test_add_regional_client_unknown_region(default_kms_cmp, patch_boto3_session
     assert test is patch_boto3_session.return_value.client.return_value
 
 
+def test_client_use_region_from_session(default_kms_cmp, patch_add_regional_client):
+    mock_session = MagicMock()
+    mock_session.get_config_variable.return_value = sentinel.region
+    default_kms_cmp._botocore_session = mock_session
+
+    test = default_kms_cmp._client('')
+
+    patch_add_regional_client.assert_called_once_with(sentinel.region)
+    assert test is patch_add_regional_client.return_value
+
+
+def test_client_use_region_from_key_id(default_kms_cmp, patch_add_regional_client):
+    mock_session = MagicMock()
+    mock_session.get_config_variable.return_value = sentinel.region
+    default_kms_cmp._botocore_session = mock_session
+
+    test = default_kms_cmp._client(_KEY_ID)
+
+    patch_add_regional_client.assert_called_once_with(_REGION)
+    assert test is patch_add_regional_client.return_value
+
+
 def test_client_no_region_found(default_kms_cmp):
     mock_session = MagicMock()
     mock_session.get_config_variable.return_value = None
@@ -282,7 +304,7 @@ def test_client_no_region_found(default_kms_cmp):
     with pytest.raises(UnknownRegionError) as excinfo:
         default_kms_cmp._client('')
 
-    excinfo.match(r'No default region found and no region determinable from key id:*')
+    excinfo.match(r'No region determinable from key id:*')
 
 
 def test_select_id(default_kms_cmp):


### PR DESCRIPTION
reverse processing order of KMS CMP client retrieval to properly select region