### PR TITLE
convert all attrs classes to use custom init methods to enable mypy to work

### DIFF
--- a/src/dynamodb_encryption_sdk/encrypted/__init__.py
+++ b/src/dynamodb_encryption_sdk/encrypted/__init__.py
@@ -30,7 +30,7 @@ from dynamodb_encryption_sdk.structures import AttributeActions, EncryptionConte
 __all__ = ('CryptoConfig',)
 
 
-@attr.s
+@attr.s(init=False)
 class CryptoConfig(object):
     """Container for all configuration needed to encrypt or decrypt an item.
 
@@ -45,6 +45,23 @@ class CryptoConfig(object):
     materials_provider = attr.ib(validator=attr.validators.instance_of(CryptographicMaterialsProvider))
     encryption_context = attr.ib(validator=attr.validators.instance_of(EncryptionContext))
     attribute_actions = attr.ib(validator=attr.validators.instance_of(AttributeActions))
+
+    def __init__(
+            self,
+            materials_provider,  # type: CryptographicMaterialsProvider
+            encryption_context,  # type: EncryptionContext
+            attribute_actions  # type: AttributeActions
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self.materials_provider = materials_provider
+        self.encryption_context = encryption_context
+        self.attribute_actions = attribute_actions
+        attr.validate(self)
+        self.__attrs_post_init__()
 
     def __attrs_post_init__(self):
         # type: () -> None

--- a/src/dynamodb_encryption_sdk/encrypted/resource.py
+++ b/src/dynamodb_encryption_sdk/encrypted/resource.py
@@ -28,7 +28,7 @@ from .table import EncryptedTable
 __all__ = ('EncryptedResource',)
 
 
-@attr.s
+@attr.s(init=False)
 class EncryptedTablesCollectionManager(object):
     # pylint: disable=too-few-public-methods
     """Tables collection manager that provides EncryptedTable objects.
@@ -49,6 +49,25 @@ class EncryptedTablesCollectionManager(object):
     _materials_provider = attr.ib(validator=attr.validators.instance_of(CryptographicMaterialsProvider))
     _attribute_actions = attr.ib(validator=attr.validators.instance_of(AttributeActions))
     _table_info_cache = attr.ib(validator=attr.validators.instance_of(TableInfoCache))
+
+    def __init__(
+            self,
+            collection,  # type: CollectionManager
+            materials_provider,  # type: CryptographicMaterialsProvider
+            attribute_actions,  # type: AttributeActions
+            table_info_cache  # type: TableInfoCache
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self._collection = collection
+        self._materials_provider = materials_provider
+        self._attribute_actions = attribute_actions
+        self._table_info_cache = table_info_cache
+        attr.validate(self)
+        self.__attrs_post_init__()
 
     def __attrs_post_init__(self):
         """Set up the translation methods."""
@@ -95,7 +114,7 @@ class EncryptedTablesCollectionManager(object):
             )
 
 
-@attr.s
+@attr.s(init=False)
 class EncryptedResource(object):
     # pylint: disable=too-few-public-methods
     """High-level helper class to provide a familiar interface to encrypted tables.
@@ -141,6 +160,28 @@ class EncryptedResource(object):
         validator=attr.validators.instance_of(bool),
         default=True
     )
+
+    def __init__(
+            self,
+            resource,  # type: ServiceResource
+            materials_provider,  # type: CryptographicMaterialsProvider
+            attribute_actions=None,  # type: Optional[AttributeActions]
+            auto_refresh_table_indexes=True  # type: Optional[bool]
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        if attribute_actions is None:
+            attribute_actions = AttributeActions()
+
+        self._resource = resource
+        self._materials_provider = materials_provider
+        self._attribute_actions = attribute_actions
+        self._auto_refresh_table_indexes = auto_refresh_table_indexes
+        attr.validate(self)
+        self.__attrs_post_init__()
 
     def __attrs_post_init__(self):
         """Set up the table info cache, encrypted tables collection manager, and translation methods."""

--- a/src/dynamodb_encryption_sdk/encrypted/table.py
+++ b/src/dynamodb_encryption_sdk/encrypted/table.py
@@ -29,7 +29,7 @@ from .item import decrypt_python_item, encrypt_python_item
 __all__ = ('EncryptedTable',)
 
 
-@attr.s
+@attr.s(init=False)
 class EncryptedTable(object):
     # pylint: disable=too-few-public-methods
     """High-level helper class to provide a familiar interface to encrypted tables.
@@ -85,6 +85,30 @@ class EncryptedTable(object):
         validator=attr.validators.instance_of(bool),
         default=True
     )
+
+    def __init__(
+            self,
+            table,  # type: ServiceResource
+            materials_provider,  # type: CryptographicMaterialsProvider
+            table_info=None,  # type: Optional[TableInfo]
+            attribute_actions=None,  # type: Optional[AttributeActions]
+            auto_refresh_table_indexes=True  # type: Optional[bool]
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        if attribute_actions is None:
+            attribute_actions = AttributeActions()
+
+        self._table = table
+        self._materials_provider = materials_provider
+        self._table_info = table_info
+        self._attribute_actions = attribute_actions
+        self._auto_refresh_table_indexes = auto_refresh_table_indexes
+        attr.validate(self)
+        self.__attrs_post_init__()
 
     def __attrs_post_init__(self):
         """Prepare table info is it was not set and set up translation methods."""

--- a/src/dynamodb_encryption_sdk/internal/crypto/authentication.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/authentication.py
@@ -14,6 +14,13 @@
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Text  # noqa pylint: disable=unused-import
+    from dynamodb_encryption_sdk.internal import dynamodb_types  # noqa pylint: disable=unused-import
+except ImportError:  # pragma: no cover
+    # We only actually need these imports when running the mypy checks
+    pass
+
 from dynamodb_encryption_sdk.delegated_keys import DelegatedKey  # noqa pylint: disable=unused-import
 from dynamodb_encryption_sdk.encrypted import CryptoConfig  # noqa pylint: disable=unused-import
 from dynamodb_encryption_sdk.identifiers import CryptoAction
@@ -71,7 +78,7 @@ def verify_item_signature(signature_attribute, encrypted_item, verification_key,
 
 
 def _string_to_sign(item, table_name, attribute_actions):
-    # type: (dynamodb_type.ITEM, Text, AttributeActions) -> bytes
+    # type: (dynamodb_types.ITEM, Text, AttributeActions) -> bytes
     """Generate the string to sign from an encrypted item and configuration.
 
     :param dict item: Encrypted DynamoDB item

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/authentication.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/authentication.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.primitives.asymmetric import padding, rsa
 import six
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from typing import Text  # noqa pylint: disable=unused-import
+    from typing import Any, Callable, Text  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
@@ -87,7 +87,7 @@ class JavaAuthenticator(object):
         """
 
 
-@attr.s
+@attr.s(init=False)
 class JavaMac(JavaAuthenticator):
     """Symmetric MAC authenticators.
 
@@ -98,6 +98,22 @@ class JavaMac(JavaAuthenticator):
     java_name = attr.ib(validator=attr.validators.instance_of(six.string_types))
     algorithm_type = attr.ib(validator=callable_validator)
     hash_type = attr.ib(validator=callable_validator)
+
+    def __init__(
+            self,
+            java_name,  # type: Text
+            algorithm_type,  # type: Callable
+            hash_type  # type: Callable
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self.java_name = java_name
+        self.algorithm_type = algorithm_type
+        self.hash_type = hash_type
+        attr.validate(self)
 
     def _build_hmac_signer(self, key):
         # type: (bytes) -> Any
@@ -182,7 +198,7 @@ class JavaMac(JavaAuthenticator):
             raise SignatureVerificationError(message)
 
 
-@attr.s
+@attr.s(init=False)
 class JavaSignature(JavaAuthenticator):
     """Asymmetric signature authenticators.
 
@@ -194,6 +210,24 @@ class JavaSignature(JavaAuthenticator):
     algorithm_type = attr.ib()
     hash_type = attr.ib(validator=callable_validator)
     padding_type = attr.ib(validator=callable_validator)
+
+    def __init__(
+            self,
+            java_name,  # type: Text
+            algorithm_type,
+            hash_type,  # type: Callable
+            padding_type  # type: Callable
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self.java_name = java_name
+        self.algorithm_type = algorithm_type
+        self.hash_type = hash_type
+        self.padding_type = padding_type
+        attr.validate(self)
 
     def validate_algorithm(self, algorithm):
         # type: (Text) -> None

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/encryption.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/encryption.py
@@ -21,7 +21,7 @@ from .primitives import (
 __all__ = ('JavaCipher',)
 
 
-@attr.s
+@attr.s(init=False)
 class JavaCipher(object):
     """Defines the encryption cipher, mode, and padding type to use for encryption.
 
@@ -35,6 +35,22 @@ class JavaCipher(object):
     cipher = attr.ib(validator=attr.validators.instance_of(JavaEncryptionAlgorithm))
     mode = attr.ib(validator=attr.validators.instance_of(JavaMode))
     padding = attr.ib(validator=attr.validators.instance_of(JavaPadding))
+
+    def __init__(
+            self,
+            cipher,  # type: JavaEncryptionAlgorithm
+            mode,  # type: JavaMode
+            padding  # type: JavaPadding
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self.cipher = cipher
+        self.mode = mode
+        self.padding = padding
+        attr.validate(self)
 
     def encrypt(self, key, data):
         """Encrypt data using loaded key.

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/primitives.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/primitives.py
@@ -22,6 +22,12 @@ from cryptography.hazmat.primitives.asymmetric import padding as asymmetric_padd
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 import six
 
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Callable, Text  # noqa pylint: disable=unused-import
+except ImportError:  # pragma: no cover
+    # We only actually need these imports when running the mypy checks
+    pass
+
 from dynamodb_encryption_sdk.exceptions import (
     DecryptionError, EncryptionError, InvalidAlgorithmError, UnwrappingError, WrappingError
 )
@@ -89,7 +95,7 @@ class JavaPadding(object):
         """Build an instance of this padding type."""
 
 
-@attr.s
+@attr.s(init=False)
 class SimplePadding(JavaPadding):
     # pylint: disable=too-few-public-methods
     """Padding types that do not require any preparation."""
@@ -97,8 +103,22 @@ class SimplePadding(JavaPadding):
     java_name = attr.ib(validator=attr.validators.instance_of(six.string_types))
     padding = attr.ib(validator=callable_validator)
 
+    def __init__(
+            self,
+            java_name,  # type: Text
+            padding  # type: Callable
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self.java_name = java_name
+        self.padding = padding
+        attr.validate(self)
+
     def build(self, block_size=None):
-        # type: (int) -> ANY
+        # type: (int) -> Any
         """Build an instance of this padding type.
 
         :param int block_size: Not used by SimplePadding. Ignored and not required.
@@ -107,7 +127,7 @@ class SimplePadding(JavaPadding):
         return self.padding()
 
 
-@attr.s
+@attr.s(init=False)
 class BlockSizePadding(JavaPadding):
     # pylint: disable=too-few-public-methods
     """Padding types that require a block size input."""
@@ -115,8 +135,22 @@ class BlockSizePadding(JavaPadding):
     java_name = attr.ib(validator=attr.validators.instance_of(six.string_types))
     padding = attr.ib(validator=callable_validator)
 
+    def __init__(
+            self,
+            java_name,  # type: Text
+            padding  # type: Callable
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self.java_name = java_name
+        self.padding = padding
+        attr.validate(self)
+
     def build(self, block_size):
-        # type: (int) -> ANY
+        # type: (int) -> Any
         """Build an instance of this padding type.
 
         :param int block_size: Block size of algorithm for which to build padder.
@@ -125,7 +159,7 @@ class BlockSizePadding(JavaPadding):
         return self.padding(block_size)
 
 
-@attr.s
+@attr.s(init=False)
 class OaepPadding(JavaPadding):
     # pylint: disable=too-few-public-methods
     """OAEP padding types. These require more complex setup.
@@ -143,8 +177,28 @@ class OaepPadding(JavaPadding):
     mgf = attr.ib(validator=callable_validator)
     mgf_digest = attr.ib(validator=callable_validator)
 
+    def __init__(
+            self,
+            java_name,  # type: Text
+            padding,  # type: Callable
+            digest,  # type: Callable
+            mgf,  # type: Callable
+            mgf_digest  # type: Callable
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self.java_name = java_name
+        self.padding = padding
+        self.digest = digest
+        self.mgf = mgf
+        self.mgf_digest = mgf_digest
+        attr.validate(self)
+
     def build(self, block_size=None):
-        # type: (int) -> ANY
+        # type: (int) -> Any
         """Build an instance of this padding type.
 
         :param int block_size: Not used by OaepPadding. Ignored and not required.
@@ -157,7 +211,7 @@ class OaepPadding(JavaPadding):
         )
 
 
-@attr.s
+@attr.s(init=False)
 class JavaMode(object):
     # pylint: disable=too-few-public-methods
     """Bridge the gap from the Java encryption mode names and Python resources.
@@ -167,8 +221,22 @@ class JavaMode(object):
     java_name = attr.ib(validator=attr.validators.instance_of(six.string_types))
     mode = attr.ib(validator=callable_validator)
 
+    def __init__(
+            self,
+            java_name,  # type: Text
+            mode  # type: Callable
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self.java_name = java_name
+        self.mode = mode
+        attr.validate(self)
+
     def build(self, iv):
-        # type: (int) -> ANY
+        # type: (int) -> Any
         """Build an instance of this mode type.
 
         :param bytes iv: Initialization vector bytes
@@ -177,7 +245,7 @@ class JavaMode(object):
         return self.mode(iv)
 
 
-@attr.s
+@attr.s(init=False)
 class JavaEncryptionAlgorithm(object):
     # pylint: disable=too-few-public-methods
     """Bridge the gap from the Java encryption algorithm names and Python resources.
@@ -186,6 +254,22 @@ class JavaEncryptionAlgorithm(object):
 
     java_name = attr.ib(validator=attr.validators.instance_of(six.string_types))
     cipher = attr.ib()
+
+    def __init__(
+            self,
+            java_name,  # type: Text
+            cipher  # type: Callable
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self.java_name = java_name
+        self.cipher = cipher
+        attr.validate(self)
+        if hasattr(self, '__attrs_post_init__'):
+            self.__attrs_post_init__()
 
     def validate_algorithm(self, algorithm):
         # type: (Text) -> None

--- a/src/dynamodb_encryption_sdk/internal/formatting/material_description.py
+++ b/src/dynamodb_encryption_sdk/internal/formatting/material_description.py
@@ -15,6 +15,13 @@ import io
 import logging
 import struct
 
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Dict, Text  # noqa pylint: disable=unused-import
+    from dynamodb_encryption_sdk.internal import dynamodb_types  # noqa pylint: disable=unused-import
+except ImportError:  # pragma: no cover
+    # We only actually need these imports when running the mypy checks
+    pass
+
 from dynamodb_encryption_sdk.exceptions import InvalidMaterialDescriptionError, InvalidMaterialDescriptionVersionError
 from dynamodb_encryption_sdk.identifiers import LOGGER_NAME
 from dynamodb_encryption_sdk.internal.identifiers import Tag

--- a/src/dynamodb_encryption_sdk/internal/identifiers.py
+++ b/src/dynamodb_encryption_sdk/internal/identifiers.py
@@ -14,7 +14,7 @@
 from enum import Enum
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from typing import Text  # noqa pylint: disable=unused-import
+    from typing import Optional, Text  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass

--- a/src/dynamodb_encryption_sdk/internal/utils.py
+++ b/src/dynamodb_encryption_sdk/internal/utils.py
@@ -20,7 +20,7 @@ from dynamodb_encryption_sdk.internal.str_ops import to_bytes
 from dynamodb_encryption_sdk.structures import EncryptionContext, TableInfo
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from typing import Callable, Dict, Text  # noqa pylint: disable=unused-import
+    from typing import Any, Callable, Dict, Text  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
@@ -50,7 +50,7 @@ def sorted_key_map(item, transform=to_bytes):
     return sorted_items
 
 
-@attr.s
+@attr.s(init=False)
 class TableInfoCache(object):
     # pylint: disable=too-few-public-methods
     """Very simple cache of TableInfo objects, providing configuration information about DynamoDB tables.
@@ -63,6 +63,21 @@ class TableInfoCache(object):
 
     _client = attr.ib(validator=attr.validators.instance_of(botocore.client.BaseClient))
     _auto_refresh_table_indexes = attr.ib(validator=attr.validators.instance_of(bool))
+
+    def __init__(
+            self,
+            client,  # type: botocore.client.BaseClient
+            auto_refresh_table_indexes  # type: bool
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self._client = client
+        self._auto_refresh_table_indexes = auto_refresh_table_indexes
+        attr.validate(self)
+        self.__attrs_post_init__()
 
     def __attrs_post_init__(self):
         """Set up the empty cache."""

--- a/src/dynamodb_encryption_sdk/material_providers/static.py
+++ b/src/dynamodb_encryption_sdk/material_providers/static.py
@@ -20,7 +20,7 @@ from . import CryptographicMaterialsProvider
 __all__ = ('StaticCryptographicMaterialsProvider',)
 
 
-@attr.s
+@attr.s(init=False)
 class StaticCryptographicMaterialsProvider(CryptographicMaterialsProvider):
     """Manually combine encryption and decryption materials for use as a cryptographic materials provider.
 
@@ -38,6 +38,20 @@ class StaticCryptographicMaterialsProvider(CryptographicMaterialsProvider):
         validator=attr.validators.optional(attr.validators.instance_of(EncryptionMaterials)),
         default=None
     )
+
+    def __init__(
+            self,
+            decryption_materials=None,  # type: Optional[DecryptionMaterials]
+            encryption_materials=None  # type: Optional[EncryptionMaterials]
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self._decryption_materials = decryption_materials
+        self._encryption_materials = encryption_materials
+        attr.validate(self)
 
     def decryption_materials(self, encryption_context):
         # type: (EncryptionContext) -> DecryptionMaterials

--- a/src/dynamodb_encryption_sdk/material_providers/wrapped.py
+++ b/src/dynamodb_encryption_sdk/material_providers/wrapped.py
@@ -22,7 +22,7 @@ from . import CryptographicMaterialsProvider
 __all__ = ('WrappedCryptographicMaterialsProvider',)
 
 
-@attr.s
+@attr.s(init=False)
 class WrappedCryptographicMaterialsProvider(CryptographicMaterialsProvider):
     """Cryptographic materials provider to use ephemeral content encryption keys wrapped by delegated keys.
 
@@ -53,6 +53,22 @@ class WrappedCryptographicMaterialsProvider(CryptographicMaterialsProvider):
         validator=attr.validators.optional(attr.validators.instance_of(DelegatedKey)),
         default=None
     )
+
+    def __init__(
+            self,
+            signing_key,  # type: DelegatedKey
+            wrapping_key=None,  # type: Optional[DelegatedKey]
+            unwrapping_key=None  # type: Optional[DelegatedKey]
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        self._signing_key = signing_key
+        self._wrapping_key = wrapping_key
+        self._unwrapping_key = unwrapping_key
+        attr.validate(self)
 
     def _build_materials(self, encryption_context):
         # type: (EncryptionContext) -> WrappedCryptographicMaterials

--- a/src/dynamodb_encryption_sdk/materials/__init__.py
+++ b/src/dynamodb_encryption_sdk/materials/__init__.py
@@ -14,6 +14,7 @@
 import abc
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Dict, Text  # noqa pylint: disable=unused-import
     from mypy_extensions import NoReturn  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks

--- a/src/dynamodb_encryption_sdk/materials/raw.py
+++ b/src/dynamodb_encryption_sdk/materials/raw.py
@@ -27,6 +27,12 @@ import copy
 import attr
 import six
 
+try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
+    from typing import Dict, Optional, Text  # noqa pylint: disable=unused-import
+except ImportError:  # pragma: no cover
+    # We only actually need these imports when running the mypy checks
+    pass
+
 from dynamodb_encryption_sdk.delegated_keys import DelegatedKey
 from dynamodb_encryption_sdk.internal.validators import dictionary_validator
 from dynamodb_encryption_sdk.materials import DecryptionMaterials, EncryptionMaterials
@@ -34,7 +40,7 @@ from dynamodb_encryption_sdk.materials import DecryptionMaterials, EncryptionMat
 __all__ = ('RawEncryptionMaterials', 'RawDecryptionMaterials')
 
 
-@attr.s
+@attr.s(init=False)
 class RawEncryptionMaterials(EncryptionMaterials):
     # inheritance confuses pylint: disable=abstract-method
     """Encryption materials for use directly with delegated keys.
@@ -60,6 +66,26 @@ class RawEncryptionMaterials(EncryptionMaterials):
         converter=copy.deepcopy,
         default=attr.Factory(dict)
     )
+
+    def __init__(
+            self,
+            signing_key,  # type: DelegatedKey
+            encryption_key=None,  # type: Optional[DelegatedKey]
+            material_description=None  # type: Optional[Dict[Text, Text]]
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        if material_description is None:
+            material_description = {}
+
+        self._signing_key = signing_key
+        self._encryption_key = encryption_key
+        self._material_description = material_description
+        attr.validate(self)
+        self.__attrs_post_init__()
 
     def __attrs_post_init__(self):
         """Verify that the encryption key is allowed be used for raw materials."""
@@ -102,7 +128,7 @@ class RawEncryptionMaterials(EncryptionMaterials):
         return self._encryption_key
 
 
-@attr.s
+@attr.s(init=False)
 class RawDecryptionMaterials(DecryptionMaterials):
     # inheritance confuses pylint: disable=abstract-method
     """Encryption materials for use directly with delegated keys.
@@ -128,6 +154,26 @@ class RawDecryptionMaterials(DecryptionMaterials):
         converter=copy.deepcopy,
         default=attr.Factory(dict)
     )
+
+    def __init__(
+            self,
+            verification_key,  # type: DelegatedKey
+            decryption_key=None,  # type: Optional[DelegatedKey]
+            material_description=None  # type: Optional[Dict[Text, Text]]
+    ):
+        # type: (...) -> None
+        """Workaround pending resolution of attrs/mypy interaction.
+        https://github.com/python/mypy/issues/2088
+        https://github.com/python-attrs/attrs/issues/215
+        """
+        if material_description is None:
+            material_description = {}
+
+        self._verification_key = verification_key
+        self._decryption_key = decryption_key
+        self._material_description = material_description
+        attr.validate(self)
+        self.__attrs_post_init__()
 
     def __attrs_post_init__(self):
         """Verify that the encryption key is allowed be used for raw materials."""


### PR DESCRIPTION
*Issue #, if available:* #4

*Description of changes:*
Because mypy cannot currently correctly read the init profile of an attrs-generated class, in order for mypy to work correctly we need to build out these `__init__` shims. These enable mypy integration at the cost of making the codebase a bit messier. Once mypy and attrs can play well together we'll be removing these shims, so they should do literally nothing except:
1. take in parameters
2. set any default values
3. assign those parameters to instance attributes
4. call attrs to run all the validators
5. if present in the class, call the `__attrs_post_init__` function (this function is used with attrs-generated classes for any custom logic that needs to happen at init time)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
