### PR TITLE
add explicit enum34 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3>=1.4.4
 cryptography>=1.8.1
 attrs>=17.4.0
+enum34; python_version < '3.4'


### PR DESCRIPTION
*Description of changes:*
We use `enum34` in Python versions before 3.4, but we have been relying on a transitive dependency through `cryptography`. Since we actually use it, we should state it explicitly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
