### PR TITLE
cleaning up attrs/mypy workaround comments to remove them from rendered docs

### DIFF
--- a/src/dynamodb_encryption_sdk/delegated_keys/jce.py
+++ b/src/dynamodb_encryption_sdk/delegated_keys/jce.py
@@ -125,13 +125,12 @@ class JceNameLocalDelegatedKey(DelegatedKey):
             key,  # type: bytes
             algorithm,  # type: Text
             key_type,  # type: EncryptionKeyType
-            key_encoding  # type: KeyEncodingType
-    ):
+            key_encoding,  # type: KeyEncodingType
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.key = key
         self._algorithm = algorithm
         self._key_type = key_type

--- a/src/dynamodb_encryption_sdk/encrypted/__init__.py
+++ b/src/dynamodb_encryption_sdk/encrypted/__init__.py
@@ -51,12 +51,11 @@ class CryptoConfig(object):
             materials_provider,  # type: CryptographicMaterialsProvider
             encryption_context,  # type: EncryptionContext
             attribute_actions  # type: AttributeActions
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.materials_provider = materials_provider
         self.encryption_context = encryption_context
         self.attribute_actions = attribute_actions

--- a/src/dynamodb_encryption_sdk/encrypted/client.py
+++ b/src/dynamodb_encryption_sdk/encrypted/client.py
@@ -55,12 +55,11 @@ class EncryptedPaginator(object):
             paginator,  # type: botocore.paginate.Paginator
             decrypt_method,  # type: Callable
             crypto_config_method  # type: Callable
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self._paginator = paginator
         self._decrypt_method = decrypt_method
         self._crypto_config_method = crypto_config_method
@@ -172,12 +171,11 @@ class EncryptedClient(object):
             attribute_actions=None,  # type: Optional[AttributeActions]
             auto_refresh_table_indexes=True,  # type: Optional[bool]
             expect_standard_dictionaries=False  # type: Optional[bool]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if attribute_actions is None:
             attribute_actions = AttributeActions()
 

--- a/src/dynamodb_encryption_sdk/encrypted/resource.py
+++ b/src/dynamodb_encryption_sdk/encrypted/resource.py
@@ -62,12 +62,11 @@ class EncryptedTablesCollectionManager(object):
             materials_provider,  # type: CryptographicMaterialsProvider
             attribute_actions,  # type: AttributeActions
             table_info_cache  # type: TableInfoCache
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self._collection = collection
         self._materials_provider = materials_provider
         self._attribute_actions = attribute_actions
@@ -173,12 +172,11 @@ class EncryptedResource(object):
             materials_provider,  # type: CryptographicMaterialsProvider
             attribute_actions=None,  # type: Optional[AttributeActions]
             auto_refresh_table_indexes=True  # type: Optional[bool]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if attribute_actions is None:
             attribute_actions = AttributeActions()
 

--- a/src/dynamodb_encryption_sdk/encrypted/table.py
+++ b/src/dynamodb_encryption_sdk/encrypted/table.py
@@ -99,12 +99,11 @@ class EncryptedTable(object):
             table_info=None,  # type: Optional[TableInfo]
             attribute_actions=None,  # type: Optional[AttributeActions]
             auto_refresh_table_indexes=True  # type: Optional[bool]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if attribute_actions is None:
             attribute_actions = AttributeActions()
 

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/authentication.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/authentication.py
@@ -104,12 +104,11 @@ class JavaMac(JavaAuthenticator):
             java_name,  # type: Text
             algorithm_type,  # type: Callable
             hash_type  # type: Callable
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.java_name = java_name
         self.algorithm_type = algorithm_type
         self.hash_type = hash_type
@@ -217,12 +216,11 @@ class JavaSignature(JavaAuthenticator):
             algorithm_type,
             hash_type,  # type: Callable
             padding_type  # type: Callable
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.java_name = java_name
         self.algorithm_type = algorithm_type
         self.hash_type = hash_type

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/encryption.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/encryption.py
@@ -41,12 +41,11 @@ class JavaCipher(object):
             cipher,  # type: JavaEncryptionAlgorithm
             mode,  # type: JavaMode
             padding  # type: JavaPadding
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.cipher = cipher
         self.mode = mode
         self.padding = padding

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/primitives.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/primitives.py
@@ -107,12 +107,11 @@ class SimplePadding(JavaPadding):
             self,
             java_name,  # type: Text
             padding  # type: Callable
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.java_name = java_name
         self.padding = padding
         attr.validate(self)
@@ -139,12 +138,11 @@ class BlockSizePadding(JavaPadding):
             self,
             java_name,  # type: Text
             padding  # type: Callable
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.java_name = java_name
         self.padding = padding
         attr.validate(self)
@@ -184,12 +182,11 @@ class OaepPadding(JavaPadding):
             digest,  # type: Callable
             mgf,  # type: Callable
             mgf_digest  # type: Callable
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.java_name = java_name
         self.padding = padding
         self.digest = digest
@@ -225,12 +222,11 @@ class JavaMode(object):
             self,
             java_name,  # type: Text
             mode  # type: Callable
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.java_name = java_name
         self.mode = mode
         attr.validate(self)
@@ -259,12 +255,11 @@ class JavaEncryptionAlgorithm(object):
             self,
             java_name,  # type: Text
             cipher  # type: Callable
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.java_name = java_name
         self.cipher = cipher
         attr.validate(self)

--- a/src/dynamodb_encryption_sdk/internal/utils.py
+++ b/src/dynamodb_encryption_sdk/internal/utils.py
@@ -68,12 +68,11 @@ class TableInfoCache(object):
             self,
             client,  # type: botocore.client.BaseClient
             auto_refresh_table_indexes  # type: bool
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self._client = client
         self._auto_refresh_table_indexes = auto_refresh_table_indexes
         attr.validate(self)

--- a/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
+++ b/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
@@ -89,12 +89,11 @@ class KeyInfo(object):
             description,  # type: Text
             algorithm,  # type: Text
             length  # type: int
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.description = description
         self.algorithm = algorithm
         self.length = length
@@ -183,12 +182,11 @@ class AwsKmsCryptographicMaterialsProvider(CryptographicMaterialsProvider):
             grant_tokens=None,  # type: Optional[Tuple[Text]]
             material_description=None,  # type: Optional[Dict[Text, Text]]
             regional_clients=None  # type: Optional[Dict[Text, botocore.client.BaseClient]]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if botocore_session is None:
             botocore_session = botocore.session.Session()
         if grant_tokens is None:

--- a/src/dynamodb_encryption_sdk/material_providers/most_recent.py
+++ b/src/dynamodb_encryption_sdk/material_providers/most_recent.py
@@ -49,6 +49,7 @@ class TtlActions(Enum):
 
 
 def _min_capacity_validator(instance, attribute, value):
+    # pylint: disable=unused-argument
     """Attrs validator to require that value is at least 1."""
     if value < 1:
         raise ValueError('Cache capacity must be at least 1')
@@ -63,12 +64,11 @@ class BasicCache(object):
         _min_capacity_validator
     ))
 
-    def __init__(self, capacity):
+    def __init__(self, capacity):  # noqa=D107
         # type: (int) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.capacity = capacity
         attr.validate(self)
         self.__attrs_post_init__()
@@ -109,7 +109,7 @@ class BasicCache(object):
         # type: () -> None
         """Clear the cache."""
         with self._cache_lock:
-            self._cache = OrderedDict()  # type: OrderedDict[Any, Any]
+            self._cache = OrderedDict()  # type: OrderedDict[Any, Any] # pylint: disable=attribute-defined-outside-init
 
 
 @attr.s(init=False)
@@ -136,12 +136,11 @@ class MostRecentProvider(CryptographicMaterialsProvider):
             provider_store,  # type: ProviderStore
             material_name,  # type: Text
             version_ttl  # type: float
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self._provider_store = provider_store
         self._material_name = material_name
         self._version_ttl = version_ttl
@@ -151,8 +150,10 @@ class MostRecentProvider(CryptographicMaterialsProvider):
     def __attrs_post_init__(self):
         # type: () -> None
         """Initialize the cache."""
-        self._lock = Lock()
-        self._cache = BasicCache(1000)
+        self._version = None  # type: int # pylint: disable=attribute-defined-outside-init
+        self._last_updated = None  # type: float # pylint: disable=attribute-defined-outside-init
+        self._lock = Lock()  # pylint: disable=attribute-defined-outside-init
+        self._cache = BasicCache(1000)  # pylint: disable=attribute-defined-outside-init
         self.refresh()
 
     def decryption_materials(self, encryption_context):
@@ -278,12 +279,9 @@ class MostRecentProvider(CryptographicMaterialsProvider):
             except KeyError:
                 ttl_action = TtlActions.EXPIRED
 
-        if ttl_action is TtlActions.GRACE_PERIOD:
-            # Just get the latest local version if we cannot acquire the lock.
-            allow_local = True
-        else:
-            # Block until we can acquire the lock.
-            allow_local = False
+        # Just get the latest local version if we cannot acquire the lock.
+        # Otherwise, block until we can acquire the lock.
+        allow_local = bool(ttl_action is TtlActions.GRACE_PERIOD)
 
         provider = self._get_most_recent_version(allow_local)
 
@@ -294,5 +292,5 @@ class MostRecentProvider(CryptographicMaterialsProvider):
         """Clear all local caches for this provider."""
         with self._lock:
             self._cache.clear()
-            self._version = None  # type: int
-            self._last_updated = None  # type: float
+            self._version = None  # type: int # pylint: disable=attribute-defined-outside-init
+            self._last_updated = None  # type: float # pylint: disable=attribute-defined-outside-init

--- a/src/dynamodb_encryption_sdk/material_providers/static.py
+++ b/src/dynamodb_encryption_sdk/material_providers/static.py
@@ -50,12 +50,11 @@ class StaticCryptographicMaterialsProvider(CryptographicMaterialsProvider):
             self,
             decryption_materials=None,  # type: Optional[DecryptionMaterials]
             encryption_materials=None  # type: Optional[EncryptionMaterials]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self._decryption_materials = decryption_materials
         self._encryption_materials = encryption_materials
         attr.validate(self)

--- a/src/dynamodb_encryption_sdk/material_providers/store/__init__.py
+++ b/src/dynamodb_encryption_sdk/material_providers/store/__init__.py
@@ -57,6 +57,7 @@ class ProviderStore(object):
 
     def max_version(self, material_name):
         # (Text) -> int
+        # pylint: disable=no-self-use
         """Find the maximum known version of the specified material.
 
         .. note::

--- a/src/dynamodb_encryption_sdk/material_providers/store/meta.py
+++ b/src/dynamodb_encryption_sdk/material_providers/store/meta.py
@@ -75,12 +75,11 @@ class MetaStore(ProviderStore):
     _table = attr.ib(validator=attr.validators.instance_of(ServiceResource))
     _materials_provider = attr.ib(validator=attr.validators.instance_of(CryptographicMaterialsProvider))
 
-    def __init__(self, table, materials_provider):
+    def __init__(self, table, materials_provider):  # noqa=D107
         # type: (ServiceResource, CryptographicMaterialsProvider) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self._table = table
         self._materials_provider = materials_provider
         attr.validate(self)

--- a/src/dynamodb_encryption_sdk/material_providers/wrapped.py
+++ b/src/dynamodb_encryption_sdk/material_providers/wrapped.py
@@ -72,12 +72,11 @@ class WrappedCryptographicMaterialsProvider(CryptographicMaterialsProvider):
             wrapping_key=None,  # type: Optional[DelegatedKey]
             unwrapping_key=None,  # type: Optional[DelegatedKey]
             material_description=None  # type: Optional[Dict[Text, Text]]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if material_description is None:
             material_description = {}
 

--- a/src/dynamodb_encryption_sdk/materials/raw.py
+++ b/src/dynamodb_encryption_sdk/materials/raw.py
@@ -72,12 +72,11 @@ class RawEncryptionMaterials(EncryptionMaterials):
             signing_key,  # type: DelegatedKey
             encryption_key=None,  # type: Optional[DelegatedKey]
             material_description=None  # type: Optional[Dict[Text, Text]]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if material_description is None:
             material_description = {}
 
@@ -160,12 +159,11 @@ class RawDecryptionMaterials(DecryptionMaterials):
             verification_key,  # type: DelegatedKey
             decryption_key=None,  # type: Optional[DelegatedKey]
             material_description=None  # type: Optional[Dict[Text, Text]]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if material_description is None:
             material_description = {}
 

--- a/src/dynamodb_encryption_sdk/materials/wrapped.py
+++ b/src/dynamodb_encryption_sdk/materials/wrapped.py
@@ -84,12 +84,11 @@ class WrappedCryptographicMaterials(CryptographicMaterials):
             wrapping_key=None,  # type: Optional[DelegatedKey]
             unwrapping_key=None,  # type: Optional[DelegatedKey]
             material_description=None  # type: Optional[Dict[Text, Text]]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if material_description is None:
             material_description = {}
 

--- a/src/dynamodb_encryption_sdk/structures.py
+++ b/src/dynamodb_encryption_sdk/structures.py
@@ -88,12 +88,11 @@ class EncryptionContext(object):
             sort_key_name=None,  # type: Optional[Text]
             attributes=None,  # type: Optional[Dict[Text, Dict]]
             material_description=None  # type: Optional[Dict[Text, Text]]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if attributes is None:
             attributes = {}
         if material_description is None:
@@ -129,12 +128,11 @@ class AttributeActions(object):
             self,
             default_action=CryptoAction.ENCRYPT_AND_SIGN,  # type: Optional[CryptoAction]
             attribute_actions=None  # type: Optional[Dict[Text, CryptoAction]]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         if attribute_actions is None:
             attribute_actions = {}
 
@@ -238,12 +236,11 @@ class TableIndex(object):
             self,
             partition,  # type: Text
             sort=None  # type: Optional[Text]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.partition = partition
         self.sort = sort
         attr.validate(self)
@@ -308,12 +305,11 @@ class TableInfo(object):
             name,  # type: Text
             primary_index=None,  # type: Optional[TableIndex]
             secondary_indexes=None  # type: Optional[Set[TableIndex]]
-    ):
+    ):  # noqa=D107
         # type: (...) -> None
-        """Workaround pending resolution of attrs/mypy interaction.
-        https://github.com/python/mypy/issues/2088
-        https://github.com/python-attrs/attrs/issues/215
-        """
+        # Workaround pending resolution of attrs/mypy interaction.
+        # https://github.com/python/mypy/issues/2088
+        # https://github.com/python-attrs/attrs/issues/215
         self.name = name
         self._primary_index = primary_index
         self._secondary_indexes = secondary_indexes


### PR DESCRIPTION
*Description of changes:*

I realized that the note about the attrs/mypy workaround added in #44 showed up in the rendered docs. This is not what we want, so this changes all of those into comments (rather than docstrings) and disables that flake8 docstring check on those methods (`noqa=D107`).

There are also a few minor fixes identified by pylint in `most_recent.py`, setting initial values for `_version` and `_last_updated` as well as simplifying a value check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
