### PR TITLE
docstring cleanup and class reference simplification

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,7 +64,7 @@ html_static_path = ['_static']
 htmlhelp_basename = '%sdoc' % project
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('http://docs.python.org/', None)}
 
 # autosummary
 autosummary_generate = True

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,6 +12,7 @@ Modules
     dynamodb_encryption_sdk.exceptions
     dynamodb_encryption_sdk.identifiers
     dynamodb_encryption_sdk.structures
+    dynamodb_encryption_sdk.transform
     dynamodb_encryption_sdk.delegated_keys
     dynamodb_encryption_sdk.delegated_keys.jce
     dynamodb_encryption_sdk.encrypted
@@ -44,7 +45,6 @@ Modules
     dynamodb_encryption_sdk.internal.crypto.jce_bridge.primitives
     dynamodb_encryption_sdk.internal.formatting
     dynamodb_encryption_sdk.internal.formatting.material_description
-    dynamodb_encryption_sdk.internal.formatting.transform
     dynamodb_encryption_sdk.internal.formatting.deserialize
     dynamodb_encryption_sdk.internal.formatting.deserialize.attribute
     dynamodb_encryption_sdk.internal.formatting.serialize

--- a/src/dynamodb_encryption_sdk/delegated_keys/__init__.py
+++ b/src/dynamodb_encryption_sdk/delegated_keys/__init__.py
@@ -26,7 +26,7 @@ __all__ = ('DelegatedKey',)
 
 
 def _raise_not_implemented(method_name):
-    """Raises a standardized ``NotImplementedError`` to report that the specified method
+    """Raises a standardized :class:`NotImplementedError` to report that the specified method
     is not supported.
 
     :raises NotImplementedError: when called
@@ -40,7 +40,7 @@ class DelegatedKey(object):
     and unwrap keys. Not all delegated keys implement all methods.
 
     Unless overridden by a subclass, any method that a delegated key does not implement raises
-    a ``NotImplementedError`` detailing this.
+    a :class:`NotImplementedError` detailing this.
     """
 
     @abc.abstractproperty
@@ -51,7 +51,8 @@ class DelegatedKey(object):
     @property
     def allowed_for_raw_materials(self):
         # type: () -> bool
-        """Most delegated keys should not be used with RawCryptographicMaterials.
+        """Most delegated keys should not be used with :class:`RawDecryptionMaterials` or
+        :class:`RawEncryptionMaterials`.
 
         :returns: False
         :rtype: bool
@@ -62,12 +63,12 @@ class DelegatedKey(object):
     def generate(cls, algorithm, key_length):  # type: ignore
         # type: (Text, int) -> DelegatedKey
         # pylint: disable=unused-argument,no-self-use
-        """Generate an instance of this DelegatedKey using the specified algorithm and key length.
+        """Generate an instance of this :class:`DelegatedKey` using the specified algorithm and key length.
 
         :param str algorithm: Text description of algorithm to be used
         :param int key_length: Size of key to generate
         :returns: Generated delegated key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         _raise_not_implemented('generate')
 
@@ -130,12 +131,11 @@ class DelegatedKey(object):
         :param str algorithm: Text description of algorithm to use to unwrap key
         :param bytes content_key: Raw content key to wrap
         :param str wrapped_key_algorithm: Text description of algorithm for unwrapped key to use
-        :param wrapped_key_type: Type of key to treat key as once unwrapped
-        :type wrapped_key_type: dynamodb_encryption_sdk.identifiers.EncryptionKeyType
+        :param EncryptionKeyType wrapped_key_type: Type of key to treat key as once unwrapped
         :param dict additional_associated_data: Not used by all delegated keys, but if it
             is, then if it is provided on wrap it must be required on unwrap.
         :returns: Delegated key using unwrapped key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         _raise_not_implemented('unwrap')
 
@@ -166,9 +166,9 @@ class DelegatedKey(object):
         # type: () -> Text
         # pylint: disable=no-self-use
         """Provide a description that can inform an appropriate cryptographic materials
-        provider about how to build a DelegatedKey for signature verification. If implemented,
-        the return value of this method is included in the material description written to
-        the encrypted item.
+        provider about how to build a :class:`DelegatedKey` for signature verification.
+        If implemented, the return value of this method is included in the material description
+        written to the encrypted item.
 
         :returns: Signing algorithm identifier
         :rtype: str

--- a/src/dynamodb_encryption_sdk/delegated_keys/jce.py
+++ b/src/dynamodb_encryption_sdk/delegated_keys/jce.py
@@ -42,7 +42,7 @@ def _generate_symmetric_key(key_length):
 
     :param int key_length: Required key length in bits
     :returns: raw key, symmetric key identifier, and RAW encoding identifier
-    :rtype: tuple of bytes, EncryptionKeyType, and KeyEncodingType
+    :rtype: tuple(bytes, :class:`EncryptionKeyType`, :class:`KeyEncodingType`)
     """
     return os.urandom(key_length // 8), EncryptionKeyType.SYMMETRIC, KeyEncodingType.RAW
 
@@ -52,7 +52,7 @@ def _generate_rsa_key(key_length):
 
     :param int key_length: Required key length in bits
     :returns: DER-encoded private key, private key identifier, and DER encoding identifier
-    :rtype: tuple of bytes, EncryptionKeyType, and KeyEncodingType
+    :rtype: tuple(bytes, :class:`EncryptionKeyType`, :class:`KeyEncodingType`)
     """
     private_key = rsa.generate_private_key(
         public_exponent=65537,
@@ -109,10 +109,8 @@ class JceNameLocalDelegatedKey(DelegatedKey):
 
     :param bytes key: Raw key bytes
     :param str algorithm: JCE Standard Algorithm Name
-    :param key_type: Identifies what type of key is being provided
-    :type key_type: dynamodb_encryption_sdk.identifiers.EncryptionKeyType
-    :param key_encoding: Identifies how the provided key is encoded
-    :type key_encoding: dynamodb_encryption_sdk.identifiers.KeyEncodingTypes
+    :param EncryptionKeyType key_type: Identifies what type of key is being provided
+    :param KeyEncodingType key_encoding: Identifies how the provided key is encoded
     """
 
     key = attr.ib(validator=attr.validators.instance_of(bytes), repr=False)
@@ -204,12 +202,13 @@ class JceNameLocalDelegatedKey(DelegatedKey):
     @classmethod
     def generate(cls, algorithm, key_length=None):
         # type: (Text, Optional[int]) -> JceNameLocalDelegatedKey
-        """Generate an instance of this DelegatedKey using the specified algorithm and key length.
+        """Generate an instance of this :class:`DelegatedKey` using the specified algorithm
+        and key length.
 
         :param str algorithm: Text description of algorithm to be used
         :param int key_length: Size in bits of key to generate
         :returns: Generated delegated key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         # Normalize to allow generating both encryption and signing keys
         algorithm_lookup = algorithm.upper()
@@ -229,8 +228,8 @@ class JceNameLocalDelegatedKey(DelegatedKey):
     @property
     def allowed_for_raw_materials(self):
         # type: () -> bool
-        """Only ``JceNameLocalDelegatedKey`` backed by AES keys are allowed to be used with
-        ``RawCryptographicMaterials``.
+        """Only :class:`JceNameLocalDelegatedKey` backed by AES keys are allowed to be used
+        with :class:`RawDecryptionMaterials` or :class:`RawEncryptionMaterials`.
 
         :returns: decision
         :rtype: bool
@@ -264,7 +263,7 @@ class JceNameLocalDelegatedKey(DelegatedKey):
             https://docs.oracle.com/javase/8/docs/api/javax/crypto/Cipher.html
         :param str name: Name associated with ciphertext data
         :param bytes ciphertext: Ciphertext data to decrypt
-        :param dict additional_associated_data: Not used by ``JceNameLocalDelegatedKey``
+        :param dict additional_associated_data: Not used by :class:`JceNameLocalDelegatedKey`
         :returns: Decrypted plaintext
         :rtype: bytes
         """
@@ -278,7 +277,7 @@ class JceNameLocalDelegatedKey(DelegatedKey):
 
         :param str algorithm: Text description of algorithm to use to wrap key
         :param bytes content_key: Raw content key to wrap
-        :param dict additional_associated_data: Not used by ``JceNameLocalDelegatedKey``
+        :param dict additional_associated_data: Not used by :class:`JceNameLocalDelegatedKey`
         :returns: Wrapped key
         :rtype: bytes
         """
@@ -296,11 +295,10 @@ class JceNameLocalDelegatedKey(DelegatedKey):
         :param str algorithm: Text description of algorithm to use to unwrap key
         :param bytes content_key: Raw content key to wrap
         :param str wrapped_key_algorithm: Text description of algorithm for unwrapped key to use
-        :param wrapped_key_type: Type of key to treat key as once unwrapped
-        :type wrapped_key_type: dynamodb_encryption_sdk.identifiers.EncryptionKeyType
-        :param dict additional_associated_data: Not used by ``JceNameLocalDelegatedKey``
+        :param EncryptionKeyType wrapped_key_type: Type of key to treat key as once unwrapped
+        :param dict additional_associated_data: Not used by :class:`JceNameLocalDelegatedKey`
         :returns: Delegated key using unwrapped key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         if wrapped_key_type is not EncryptionKeyType.SYMMETRIC:
             raise UnwrappingError('Unsupported wrapped key type: "{}"'.format(wrapped_key_type))

--- a/src/dynamodb_encryption_sdk/encrypted/__init__.py
+++ b/src/dynamodb_encryption_sdk/encrypted/__init__.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover
 from dynamodb_encryption_sdk.exceptions import InvalidArgumentError
 from dynamodb_encryption_sdk.identifiers import CryptoAction
 from dynamodb_encryption_sdk.material_providers import CryptographicMaterialsProvider
-from dynamodb_encryption_sdk.materials import DecryptionMaterials, EncryptionMaterials  # noqa pylint: disable=unused-import
+from dynamodb_encryption_sdk.materials import CryptographicMaterials  # noqa pylint: disable=unused-import
 from dynamodb_encryption_sdk.structures import AttributeActions, EncryptionContext
 
 __all__ = ('CryptoConfig',)
@@ -34,12 +34,12 @@ __all__ = ('CryptoConfig',)
 class CryptoConfig(object):
     """Container for all configuration needed to encrypt or decrypt an item.
 
-    :param materials_provider: Cryptographic materials provider to use
-    :type materials_provider: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
-    :param encryption_context: Context data describing what is being encrypted or decrypted.
-    :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
-    :param attribute_actions: Description of what action should be taken for each attribute
-    :type attribute_actions: dynamodb_encryption_sdk.structures.AttributeActions
+    :param CryptographicMaterialsProvider materials_provider: Cryptographic materials provider
+        to use
+    :param EncryptionContext encryption_context: Context data describing what is being encrypted
+        or decrypted
+    :param AttributeActions attribute_actions: Description of what action should be taken
+        for each attribute
     """
 
     materials_provider = attr.ib(validator=attr.validators.instance_of(CryptographicMaterialsProvider))
@@ -75,20 +75,20 @@ class CryptoConfig(object):
                 raise InvalidArgumentError('Cannot encrypt sort key')
 
     def decryption_materials(self):
-        # type: () -> DecryptionMaterials
+        # type: () -> CryptographicMaterials
         """Load decryption materials from instance resources.
 
         :returns: Decryption materials
-        :rtype: dynamodb_encryption_sdk.materials.DecryptionMaterials
+        :rtype: CryptographicMaterials
         """
         return self.materials_provider.decryption_materials(self.encryption_context)
 
     def encryption_materials(self):
-        # type: () -> EncryptionMaterials
+        # type: () -> CryptographicMaterials
         """Load encryption materials from instance resources.
 
         :returns: Encryption materials
-        :rtype: dynamodb_encryption_sdk.materials.EncryptionMaterials
+        :rtype: CryptographicMaterials
         """
         return self.materials_provider.encryption_materials(self.encryption_context)
 
@@ -96,7 +96,7 @@ class CryptoConfig(object):
         # type: () -> CryptoConfig
         """Return a copy of this instance with a copied instance of its encryption context.
 
-        :returns: New CryptoConfig identical to this one
+        :returns: New :class:`CryptoConfig` identical to this one
         :rtype: CryptoConfig
         """
         return CryptoConfig(

--- a/src/dynamodb_encryption_sdk/encrypted/client.py
+++ b/src/dynamodb_encryption_sdk/encrypted/client.py
@@ -33,7 +33,7 @@ from dynamodb_encryption_sdk.material_providers import CryptographicMaterialsPro
 from dynamodb_encryption_sdk.structures import AttributeActions
 from .item import decrypt_dynamodb_item, decrypt_python_item, encrypt_dynamodb_item, encrypt_python_item
 
-__all__ = ('EncryptedClient',)
+__all__ = ('EncryptedClient', 'EncryptedPaginator')
 
 
 @attr.s(init=False)
@@ -42,8 +42,8 @@ class EncryptedPaginator(object):
 
     :param paginator: Pre-configured boto3 DynamoDB paginator object
     :type paginator: botocore.paginate.Paginator
-    :param decrypt_method: Item decryptor method from ``dynamodb_encryption_sdk.encrypted.item``
-    :param callable crypto_config_method: Callable that returns a crypto config
+    :param decrypt_method: Item decryptor method from :mod:`dynamodb_encryption_sdk.encrypted.item`
+    :param callable crypto_config_method: Callable that returns a :class:`CryptoConfig`
     """
 
     _paginator = attr.ib(validator=attr.validators.instance_of(botocore.paginate.Paginator))
@@ -130,7 +130,7 @@ class EncryptedClient(object):
 
         If you want to provide per-request cryptographic details, the ``put_item``, ``get_item``,
         ``query``, ``scan``, ``batch_write_item``, and ``batch_get_item`` methods will also
-        accept a ``crypto_config`` parameter, defining a custom ``CryptoConfig`` instance
+        accept a ``crypto_config`` parameter, defining a custom :class:`CryptoConfig` instance
         for this request.
 
     .. warning::
@@ -139,10 +139,10 @@ class EncryptedClient(object):
 
     :param table: Pre-configured boto3 DynamoDB client object
     :type table: boto3.resources.base.BaseClient
-    :param materials_provider: Cryptographic materials provider to use
-    :type materials_provider: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
-    :param attribute_actions: Table-level configuration of how to encrypt/sign attributes
-    :type attribute_actions: dynamodb_encryption_sdk.structures.AttributeActions
+    :param CryptographicMaterialsProvider materials_provider: Cryptographic materials provider
+        to use
+    :param AttributeActions attribute_actions: Table-level configuration of how to encrypt/sign
+        attributes
     :param bool auto_refresh_table_indexes: Should we attempt to refresh information about table indexes?
         Requires ``dynamodb:DescribeTable`` permissions on each table. (default: True)
     :param bool expect_standard_dictionaries: Should we expect items to be standard Python
@@ -259,7 +259,10 @@ class EncryptedClient(object):
         return getattr(self._client, name)
 
     def update_item(self, **kwargs):
-        """Update item is not yet supported."""
+        """Update item is not yet supported.
+
+        :raises NotImplementedError: if called
+        """
         raise NotImplementedError('"update_item" is not yet implemented')
 
     def get_paginator(self, operation_name):
@@ -268,7 +271,7 @@ class EncryptedClient(object):
 
         :param str operation_name: Name of operation for which to get paginator
         :returns: Paginator for name
-        :rtype: Paginator or EncryptedPaginator
+        :rtype: :class:`botocore.paginate.Paginator` or :class:`EncryptedPaginator`
         """
         paginator = self._client.get_paginator(operation_name)
 

--- a/src/dynamodb_encryption_sdk/encrypted/item.py
+++ b/src/dynamodb_encryption_sdk/encrypted/item.py
@@ -42,8 +42,7 @@ def encrypt_dynamodb_item(item, crypto_config):
         This handles DynamoDB-formatted items and is for use with the boto3 DynamoDB client.
 
     :param dict item: Plaintext DynamoDB item
-    :param crypto_config: Cryptographic configuration
-    :type crypto_config: dynamodb_encryption_sdk.encrypted.CryptoConfig
+    :param CryptoConfig crypto_config: Cryptographic configuration
     :returns: Encrypted and signed DynamoDB item
     :rtype: dict
     """
@@ -118,8 +117,7 @@ def encrypt_python_item(item, crypto_config):
         This handles human-friendly dictionaries and is for use with the boto3 DynamoDB service or table resource.
 
     :param dict item: Plaintext dictionary
-    :param crypto_config: Cryptographic configuration
-    :type crypto_config: dynamodb_encryption_sdk.encrypted.CryptoConfig
+    :param CryptoConfig crypto_config: Cryptographic configuration
     :returns: Encrypted and signed dictionary
     :rtype: dict
     """
@@ -137,8 +135,7 @@ def decrypt_dynamodb_item(item, crypto_config):
         This handles DynamoDB-formatted items and is for use with the boto3 DynamoDB client.
 
     :param dict item: Encrypted and signed DynamoDB item
-    :param crypto_config: Cryptographic configuration
-    :type crypto_config: dynamodb_encryption_sdk.encrypted.CryptoConfig
+    :param CryptoConfig crypto_config: Cryptographic configuration
     :returns: Plaintext DynamoDB item
     :rtype: dict
     """
@@ -212,8 +209,7 @@ def decrypt_python_item(item, crypto_config):
         This handles human-friendly dictionaries and is for use with the boto3 DynamoDB service or table resource.
 
     :param dict item: Encrypted and signed dictionary
-    :param crypto_config: Cryptographic configuration
-    :type crypto_config: dynamodb_encryption_sdk.encrypted.CryptoConfig
+    :param CryptoConfig crypto_config: Cryptographic configuration
     :returns: Plaintext dictionary
     :rtype: dict
     """

--- a/src/dynamodb_encryption_sdk/encrypted/resource.py
+++ b/src/dynamodb_encryption_sdk/encrypted/resource.py
@@ -31,24 +31,21 @@ from dynamodb_encryption_sdk.structures import AttributeActions
 from .item import decrypt_python_item, encrypt_python_item
 from .table import EncryptedTable
 
-__all__ = ('EncryptedResource',)
+__all__ = ('EncryptedResource', 'EncryptedTablesCollectionManager')
 
 
 @attr.s(init=False)
 class EncryptedTablesCollectionManager(object):
     # pylint: disable=too-few-public-methods
-    """Tables collection manager that provides EncryptedTable objects.
+    """Tables collection manager that provides :class:`EncryptedTable` objects.
 
     https://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.ServiceResource.tables
 
     :param collection: Pre-configured boto3 DynamoDB table collection manager
     :type collection: boto3.resources.collection.CollectionManager
-    :param materials_provider: Cryptographic materials provider to use
-    :type materials_provider: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
-    :param attribute_actions: Table-level configuration of how to encrypt/sign attributes
-    :type attribute_actions: dynamodb_encryption_sdk.structures.AttributeActions
-    :param table_info_cache: Local cache from which to obtain TableInfo data
-    :type table_info_cache: dynamodb_encryption_sdk.internal.utils.TableInfoCache
+    :param CryptographicMaterialsProvider materials_provider: Cryptographic materials provider to use
+    :param AttributeActions attribute_actions: Table-level configuration of how to encrypt/sign attributes
+    :param TableInfoCache table_info_cache: Local cache from which to obtain TableInfo data
     """
 
     _collection = attr.ib(validator=attr.validators.instance_of(CollectionManager))
@@ -144,14 +141,12 @@ class EncryptedResource(object):
 
         If you want to provide per-request cryptographic details, the ``batch_write_item``
         and ``batch_get_item`` methods will also accept a ``crypto_config`` parameter, defining
-        a custom ``CryptoConfig`` instance for this request.
+        a custom :class:`CryptoConfig` instance for this request.
 
     :param resource: Pre-configured boto3 DynamoDB service resource object
     :type resource: boto3.resources.base.ServiceResource
-    :param materials_provider: Cryptographic materials provider to use
-    :type materials_provider: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
-    :param attribute_actions: Table-level configuration of how to encrypt/sign attributes
-    :type attribute_actions: dynamodb_encryption_sdk.structures.AttributeActions
+    :param CryptographicMaterialsProvider materials_provider: Cryptographic materials provider to use
+    :param AttributeActions attribute_actions: Table-level configuration of how to encrypt/sign attributes
     :param bool auto_refresh_table_indexes: Should we attempt to refresh information about table indexes?
         Requires ``dynamodb:DescribeTable`` permissions on each table. (default: True)
     """
@@ -240,12 +235,11 @@ class EncryptedResource(object):
         https://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.ServiceResource.Table
 
         :param name: The table name.
-        :param materials_provider: Cryptographic materials provider to use (optional)
-        :type materials_provider: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
-        :param table_info: Information about the target DynamoDB table (optional)
-        :type table_info: dynamodb_encryption_sdk.structures.TableInfo
-        :param attribute_actions: Table-level configuration of how to encrypt/sign attributes (optional)
-        :type attribute_actions: dynamodb_encryption_sdk.structures.AttributeActions
+        :param CryptographicMaterialsProvider materials_provider: Cryptographic materials
+            provider to use (optional)
+        :param TableInfo table_info: Information about the target DynamoDB table (optional)
+        :param AttributeActions attribute_actions: Table-level configuration of how to encrypt/sign
+            attributes (optional)
         """
         table_kwargs = dict(
             table=self._resource.Table(name),

--- a/src/dynamodb_encryption_sdk/encrypted/table.py
+++ b/src/dynamodb_encryption_sdk/encrypted/table.py
@@ -59,7 +59,7 @@ class EncryptedTable(object):
 
         If you want to provide per-request cryptographic details, the ``put_item``, ``get_item``,
         ``query``, and ``scan`` methods will also accept a ``crypto_config`` parameter, defining
-        a custom ``CryptoConfig`` instance for this request.
+        a custom :class:`CryptoConfig` instance for this request.
 
     .. warning::
 
@@ -67,12 +67,11 @@ class EncryptedTable(object):
 
     :param table: Pre-configured boto3 DynamoDB Table object
     :type table: boto3.resources.base.ServiceResource
-    :param materials_provider: Cryptographic materials provider to use
-    :type materials_provider: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
-    :param table_info: Information about the target DynamoDB table
-    :type table_info: dynamodb_encryption_sdk.structures.TableInfo
-    :param attribute_actions: Table-level configuration of how to encrypt/sign attributes
-    :type attribute_actions: dynamodb_encryption_sdk.structures.AttributeActions
+    :param CryptographicMaterialsProvider materials_provider: Cryptographic materials provider
+        to use
+    :param TableInfo table_info: Information about the target DynamoDB table
+    :param AttributeActions attribute_actions: Table-level configuration of how to encrypt/sign
+        attributes
     :param bool auto_refresh_table_indexes: Should we attempt to refresh information about table indexes?
         Requires ``dynamodb:DescribeTable`` permissions on each table. (default: True)
     """

--- a/src/dynamodb_encryption_sdk/internal/crypto/authentication.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/authentication.py
@@ -36,10 +36,8 @@ def sign_item(encrypted_item, signing_key, crypto_config):
     """Generate the signature DynamoDB atttribute.
 
     :param dict encrypted_item: Encrypted DynamoDB item
-    :param signing_key: DelegatedKey to use to calculate the signature
-    :type signing_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
-    :param crypto_config: Cryptographic configuration
-    :type crypto_config: dynamodb_encryption_sdk.encrypted.CryptoConfig
+    :param DelegatedKey signing_key: DelegatedKey to use to calculate the signature
+    :param CryptoConfig crypto_config: Cryptographic configuration
     :returns: Item signature DynamoDB attribute value
     :rtype: dict
     """
@@ -60,10 +58,8 @@ def verify_item_signature(signature_attribute, encrypted_item, verification_key,
 
     :param dict signature_attribute: Item signature DynamoDB attribute value
     :param dict encrypted_item: Encrypted DynamoDB item
-    :param verification_key: DelegatedKey to use to calculate the signature
-    :type verification_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
-    :param crypto_config: Cryptographic configuration
-    :type crypto_config: dynamodb_encryption_sdk.encrypted.CryptoConfig
+    :param DelegatedKey verification_key: DelegatedKey to use to calculate the signature
+    :param CryptoConfig crypto_config: Cryptographic configuration
     """
     signature = signature_attribute[Tag.BINARY.dynamodb_tag]
     verification_key.verify(
@@ -83,7 +79,7 @@ def _string_to_sign(item, table_name, attribute_actions):
 
     :param dict item: Encrypted DynamoDB item
     :param str table_name: Table name to use when generating the string to sign
-    :type attribute_actions: dynamodb_encryption_sdk.structures.AttributeActions
+    :param AttributeActions attribute_actions: Actions to take for item
     """
     hasher = hashes.Hash(
         hashes.SHA256(),

--- a/src/dynamodb_encryption_sdk/internal/crypto/encryption.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/encryption.py
@@ -32,8 +32,7 @@ def encrypt_attribute(attribute_name, attribute, encryption_key, algorithm):
 
     :param str attribute_name: DynamoDB attribute name
     :param dict attribute: Plaintext DynamoDB attribute
-    :param encryption_key: DelegatedKey to use to encrypt the attribute
-    :type encryption_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+    :param DelegatedKey encryption_key: DelegatedKey to use to encrypt the attribute
     :param str algorithm: Encryption algorithm descriptor (passed to encryption_key as algorithm)
     :returns: Encrypted DynamoDB binary attribute
     :rtype: dict
@@ -53,8 +52,7 @@ def decrypt_attribute(attribute_name, attribute, decryption_key, algorithm):
 
     :param str attribute_name: DynamoDB attribute name
     :param dict attribute: Encrypted DynamoDB attribute
-    :param encryption_key: DelegatedKey to use to encrypt the attribute
-    :type encryption_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+    :param DelegatedKey encryption_key: DelegatedKey to use to encrypt the attribute
     :param str algorithm: Decryption algorithm descriptor (passed to encryption_key as algorithm)
     :returns: Plaintext DynamoDB attribute
     :rtype: dict

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/authentication.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/authentication.py
@@ -46,10 +46,8 @@ class JavaAuthenticator(object):
         """Load a key from bytes.
 
         :param bytes key: Raw key bytes to load
-        :param key_type: Type of key to load
-        :type key_type: dynamodb_encryption_sdk.identifiers.EncryptionKeyType
-        :param key_encoding: Encoding used to serialize ``key``
-        :type key_encoding: dynamodb_encryption_sdk.identifiers.KeyEncodingType
+        :param EncryptionKeyType key_type: Type of key to load
+        :param KeyEncodingType key_encoding: Encoding used to serialize ``key``
         :returns: Loaded key
         :rtype: bytes
         """
@@ -132,10 +130,8 @@ class JavaMac(JavaAuthenticator):
         """Load a raw key from bytes.
 
         :param bytes key: Raw key bytes to load
-        :param key_type: Type of key to load
-        :type key_type: dynamodb_encryption_sdk.identifiers.EncryptionKeyType
-        :param key_encoding: Encoding used to serialize ``key``
-        :type key_encoding: dynamodb_encryption_sdk.identifiers.KeyEncodingType
+        :param EncryptionKeyType key_type: Type of key to load
+        :param KeyEncodingType key_encoding: Encoding used to serialize ``key``
         :returns: Loaded key
         :rtype: bytes
         :raises ValueError: if ``key_type`` is not symmetric or ``key_encoding`` is not raw
@@ -250,10 +246,8 @@ class JavaSignature(JavaAuthenticator):
         """Load a key object from the provided raw key bytes.
 
         :param bytes key: Raw key bytes to load
-        :param key_type: Type of key to load
-        :type key_type: dynamodb_encryption_sdk.identifiers.EncryptionKeyType
-        :param key_encoding: Encoding used to serialize ``key``
-        :type key_encoding: dynamodb_encryption_sdk.identifiers.KeyEncodingType
+        :param EncryptionKeyType key_type: Type of key to load
+        :param KeyEncodingType key_encoding: Encoding used to serialize ``key``
         :returns: Loaded key
         :rtype: TODO:
         :raises ValueError: if ``key_type`` and ``key_encoding`` are not a valid pairing

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/encryption.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/encryption.py
@@ -27,9 +27,9 @@ class JavaCipher(object):
 
     https://docs.oracle.com/javase/8/docs/api/javax/crypto/Cipher.html
 
-    :param cipher: TODO:
-    :param mode: TODO:
-    :param padding: TODO:
+    :param JavaEncryptionAlgorithm cipher: Encryption algorithm to use
+    :param JavaMode mode: Encryption mode to use
+    :param JavaPadding padding: Encryption padding to use
     """
 
     cipher = attr.ib(validator=attr.validators.instance_of(JavaEncryptionAlgorithm))
@@ -145,7 +145,7 @@ class JavaCipher(object):
 
         :param str cipher_transformation: Formatted transformation
         :returns: JavaCipher instance
-        :rtype: dynamodb_encryption_sdk.internal.structures.EncryptionClient
+        :rtype: JavaCipher
         """
         if cipher_transformation == 'AESWrap':
             # AESWrap does not support encrypt or decrypt, so mode and padding are never

--- a/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/primitives.py
+++ b/src/dynamodb_encryption_sdk/internal/crypto/jce_bridge/primitives.py
@@ -169,6 +169,9 @@ class OaepPadding(JavaPadding):
         By default, Java incorrectly implements RSA OAEP for all hash functions besides SHA1.
         The same hashing algorithm should be used by both OAEP and the MGF, but by default
         Java always uses SHA1 for the MGF.
+
+        Because we need to match this behavior, all :class:`OaepPadding` instances should be
+        created with MGF1-SHA1.
     """
 
     java_name = attr.ib(validator=attr.validators.instance_of(six.string_types))
@@ -314,10 +317,8 @@ class JavaSymmetricEncryptionAlgorithm(JavaEncryptionAlgorithm):
         """Load a key from bytes.
 
         :param bytes key: Key bytes
-        :param key_type: Type of key
-        :type key_type: dynamodb_encryption_sdk.identifiers.EncryptionKeyType
-        :param key_encoding: Encoding used to serialize key
-        :type key_encoding: dynamodb_encryption_sdk.identifiers.KeyEncodingType
+        :param EncryptionKeyType key_type: Type of key
+        :param KeyEncodingType key_encoding: Encoding used to serialize key
         :returns: Loaded key
         """
         if key_type is not EncryptionKeyType.SYMMETRIC:
@@ -386,10 +387,8 @@ class JavaSymmetricEncryptionAlgorithm(JavaEncryptionAlgorithm):
 
         :param bytes key: Loaded encryption key
         :param bytes data: Data to encrypt
-        :param mode: Encryption mode to use
-        :type mode: dynamodb_encryption_sdk.internal.crypto.jce_bridge.primitives.JavaMode
-        :param padding: Padding mode to use
-        :type padding: dynamodb_encryption_sdk.internal.crypto.jce_bridge.primitives.JavaPadding
+        :param JavaMode mode: Encryption mode to use
+        :param JavaPadding padding: Padding mode to use
         :returns: IV prepended to encrypted data
         :rtype: bytes
         """
@@ -418,10 +417,8 @@ class JavaSymmetricEncryptionAlgorithm(JavaEncryptionAlgorithm):
 
         :param bytes key: Loaded decryption key
         :param bytes data: IV prepended to encrypted data
-        :param mode: Decryption mode to use
-        :type mode: dynamodb_encryption_sdk.internal.crypto.jce_bridge.primitives.JavaMode
-        :param padding: Padding mode to use
-        :type padding: dynamodb_encryption_sdk.internal.crypto.jce_bridge.primitives.JavaPadding
+        :param JavaMode mode: Decryption mode to use
+        :param JavaPadding padding: Padding mode to use
         :returns: Decrypted data
         :rtype: bytes
         """
@@ -464,10 +461,8 @@ def load_rsa_key(key, key_type, key_encoding):
     """Load an RSA key object from the provided raw key bytes.
 
     :param bytes key: Raw key bytes to load
-    :param key_type: Type of key to load
-    :type key_type: dynamodb_encryption_sdk.identifiers.EncryptionKeyType
-    :param key_encoding: Encoding used to serialize ``key``
-    :type key_encoding: dynamodb_encryption_sdk.identifiers.KeyEncodingType
+    :param EncryptionKeyType key_type: Type of key to load
+    :param KeyEncodingType key_encoding: Encoding used to serialize ``key``
     :returns: Loaded key
     :rtype: TODO:
     :raises ValueError: if ``key_type`` and ``key_encoding`` are not a valid pairing
@@ -499,10 +494,8 @@ class JavaAsymmetricEncryptionAlgorithm(JavaEncryptionAlgorithm):
         """Load a key from bytes.
 
         :param bytes key: Key bytes
-        :param key_type: Type of key
-        :type key_type: dynamodb_encryption_sdk.identifiers.EncryptionKeyType
-        :param key_encoding: Encoding used to serialize key
-        :type key_encoding: dynamodb_encryption_sdk.identifiers.KeyEncodingType
+        :param EncryptionKeyType key_type: Type of key
+        :param KeyEncodingType key_encoding: Encoding used to serialize key
         :returns: Loaded key
         """
         if key_type not in (EncryptionKeyType.PRIVATE, EncryptionKeyType.PUBLIC):
@@ -525,10 +518,8 @@ class JavaAsymmetricEncryptionAlgorithm(JavaEncryptionAlgorithm):
 
         :param bytes key: Loaded encryption key
         :param bytes data: Data to encrypt
-        :param mode: Encryption mode to use (not used by ``JavaAsymmetricEncryptionAlgorithm``)
-        :type mode: dynamodb_encryption_sdk.internal.crypto.jce_bridge.primitives.JavaMode
-        :param padding: Padding mode to use
-        :type padding: dynamodb_encryption_sdk.internal.crypto.jce_bridge.primitives.JavaPadding
+        :param JavaMode mode: Encryption mode to use (not used by :class:`JavaAsymmetricEncryptionAlgorithm`)
+        :param JavaPadding padding: Padding mode to use
         :returns: Encrypted data
         :rtype: bytes
         """
@@ -549,10 +540,8 @@ class JavaAsymmetricEncryptionAlgorithm(JavaEncryptionAlgorithm):
 
         :param bytes key: Loaded decryption key
         :param bytes data: IV prepended to encrypted data
-        :param mode: Decryption mode to use (not used by ``JavaAsymmetricEncryptionAlgorithm``)
-        :type mode: dynamodb_encryption_sdk.internal.crypto.jce_bridge.primitives.JavaMode
-        :param padding: Padding mode to use
-        :type padding: dynamodb_encryption_sdk.internal.crypto.jce_bridge.primitives.JavaPadding
+        :param JavaMode mode: Decryption mode to use (not used by :class:`JavaAsymmetricEncryptionAlgorithm`)
+        :param JavaPadding padding: Padding mode to use
         :returns: Decrypted data
         :rtype: bytes
         """

--- a/src/dynamodb_encryption_sdk/internal/formatting/deserialize/attribute.py
+++ b/src/dynamodb_encryption_sdk/internal/formatting/deserialize/attribute.py
@@ -38,7 +38,12 @@ _LOGGER = logging.getLogger(LOGGER_NAME)
 
 def deserialize_attribute(serialized_attribute):  # noqa: C901 pylint: disable=too-many-locals
     # type: (bytes) -> dynamodb_types.RAW_ATTRIBUTE
-    """Deserializes serialized attributes for decryption."""
+    """Deserializes serialized attributes for decryption.
+
+    :param bytes serialized_attribute: Serialized attribute bytes
+    :returns: Deserialized attribute
+    :rtype: dict
+    """
 
     def _transform_binary_value(value):
         # (bytes) -> bytes

--- a/src/dynamodb_encryption_sdk/internal/formatting/material_description.py
+++ b/src/dynamodb_encryption_sdk/internal/formatting/material_description.py
@@ -41,6 +41,7 @@ def serialize(material_description):
     :param dict material_description: Material description dictionary
     :returns: Serialized material description as a DynamoDB binary attribute value
     :rtype: dict
+    :raises InvalidMaterialDescriptionError: if invalid name or value found in material description
     """
     material_description_bytes = bytearray(_MATERIAL_DESCRIPTION_VERSION)
 
@@ -67,7 +68,8 @@ def deserialize(serialized_material_description):
     :param dict serialized_material_description: DynamoDB attribute value containing serialized material description.
     :returns: Material description dictionary
     :rtype: dict
-    :raises InvalidMaterialDescriptionError: if material description is invalid or malformed
+    :raises InvalidMaterialDescriptionError: if malformed version
+    :raises InvalidMaterialDescriptionVersionError: if unknown version is found
     """
     try:
         _raw_material_description = serialized_material_description[Tag.BINARY.dynamodb_tag]

--- a/src/dynamodb_encryption_sdk/internal/formatting/serialize/attribute.py
+++ b/src/dynamodb_encryption_sdk/internal/formatting/serialize/attribute.py
@@ -39,7 +39,7 @@ def serialize_attribute(attribute):  # noqa: C901 pylint: disable=too-many-local
     # type: (dynamodb_types.RAW_ATTRIBUTE) -> bytes
     """Serializes a raw attribute to a byte string as defined for the DynamoDB Client-Side Encryption Standard.
 
-    :param attribute: Item attribute value
+    :param dict attribute: Item attribute value
     :returns: Serialized attribute
     :rtype: bytes
     """

--- a/src/dynamodb_encryption_sdk/internal/identifiers.py
+++ b/src/dynamodb_encryption_sdk/internal/identifiers.py
@@ -90,7 +90,7 @@ class SignatureValues(Enum):
 
     def __init__(self, raw, sha256):
         # type: (bytes, bytes) -> None
-        """Set up a new SignatureValues object.
+        """Set up a new :class:`SignatureValues` object.
 
         :param bytes raw: Raw value
         :param bytes sha256: SHA256 hash of raw value

--- a/src/dynamodb_encryption_sdk/internal/utils.py
+++ b/src/dynamodb_encryption_sdk/internal/utils.py
@@ -40,7 +40,7 @@ def sorted_key_map(item, transform=to_bytes):
     :param dict item: Source dictionary
     :param function transform: Transform function
     :returns: List of tuples containing transformed key, original value, and original key for each entry
-    :rtype: list of tuples
+    :rtype: list(tuple)
     """
     sorted_items = []
     for key, value in item.items():
@@ -89,7 +89,7 @@ class TableInfoCache(object):
 
         :param str table_name: Name of table
         :returns: TableInfo describing the requested table
-        :rtype: dynamodb_encryption_sdk.structures.TableInfo
+        :rtype: TableInfo
         """
         try:
             return self._all_tables_info[table_name]
@@ -136,7 +136,7 @@ def crypto_config_from_table_info(materials_provider, attribute_actions, table_i
     """Build a crypto config from the provided values and table info.
 
     :returns: crypto config and updated kwargs
-    :rtype: dynamodb_encryption_sdk.encrypted.CryptoConfig and dict
+    :rtype: tuple(CryptoConfig, dict)
     """
     return CryptoConfig(
         materials_provider=materials_provider,
@@ -149,7 +149,7 @@ def crypto_config_from_cache(materials_provider, attribute_actions, table_info_c
     """Build a crypto config from the provided values, loading the table info from the provided cache.
 
     :returns: crypto config and updated kwargs
-    :rtype: dynamodb_encryption_sdk.encrypted.CryptoConfig and dict
+    :rtype: tuple(CryptoConfig, dict)
     """
     table_info = table_info_cache.table_info(table_name)
 
@@ -165,8 +165,11 @@ def decrypt_multi_get(decrypt_method, crypto_config_method, read_method, **kwarg
     """Transparently decrypt multiple items after getting them from the table.
 
     :param callable decrypt_method: Method to use to decrypt items
-    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a ``CryptoConfig``
+    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a :class:`CryptoConfig`
     :param callable read_method: Method that reads from the table
+    :param **kwargs: Keyword arguments to pass to ``read_method``
+    :return: DynamoDB response
+    :rtype: dict
     """
     validate_get_arguments(kwargs)
     crypto_config, ddb_kwargs = crypto_config_method(**kwargs)
@@ -185,8 +188,11 @@ def decrypt_get_item(decrypt_method, crypto_config_method, read_method, **kwargs
     """Transparently decrypt an item after getting it from the table.
 
     :param callable decrypt_method: Method to use to decrypt item
-    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a ``CryptoConfig``
+    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a :class:`CryptoConfig`
     :param callable read_method: Method that reads from the table
+    :param **kwargs: Keyword arguments to pass to ``read_method``
+    :return: DynamoDB response
+    :rtype: dict
     """
     validate_get_arguments(kwargs)
     crypto_config, ddb_kwargs = crypto_config_method(**kwargs)
@@ -205,8 +211,11 @@ def decrypt_batch_get_item(decrypt_method, crypto_config_method, read_method, **
     """Transparently decrypt multiple items after getting them in a batch request.
 
     :param callable decrypt_method: Method to use to decrypt items
-    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a ``CryptoConfig``
+    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a :class:`CryptoConfig`
     :param callable read_method: Method that reads from the table
+    :param **kwargs: Keyword arguments to pass to ``read_method``
+    :return: DynamoDB response
+    :rtype: dict
     """
     request_crypto_config = kwargs.pop('crypto_config', None)
 
@@ -234,8 +243,11 @@ def encrypt_put_item(encrypt_method, crypto_config_method, write_method, **kwarg
     """Transparently encrypt an item before putting it to the table.
 
     :param callable encrypt_method: Method to use to encrypt items
-    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a ``CryptoConfig``
-    :param callable read_method: Method that reads from the table
+    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a :class:`CryptoConfig`
+    :param callable write_method: Method that writes to the table
+    :param **kwargs: Keyword arguments to pass to ``write_method``
+    :return: DynamoDB response
+    :rtype: dict
     """
     crypto_config, ddb_kwargs = crypto_config_method(**kwargs)
     ddb_kwargs['Item'] = encrypt_method(
@@ -251,8 +263,11 @@ def encrypt_batch_write_item(encrypt_method, crypto_config_method, write_method,
     """Transparently encrypt multiple items before putting them in a batch request.
 
     :param callable encrypt_method: Method to use to encrypt items
-    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a ``CryptoConfig``
-    :param callable read_method: Method that reads from the table
+    :param callable crypto_config_method: Method that accepts ``kwargs`` and provides a :class:`CryptoConfig`
+    :param callable write_method: Method that writes to the table
+    :param **kwargs: Keyword arguments to pass to ``write_method``
+    :return: DynamoDB response
+    :rtype: dict
     """
     request_crypto_config = kwargs.pop('crypto_config', None)
 

--- a/src/dynamodb_encryption_sdk/material_providers/__init__.py
+++ b/src/dynamodb_encryption_sdk/material_providers/__init__.py
@@ -25,8 +25,7 @@ class CryptographicMaterialsProvider(object):
         # pylint: disable=unused-argument,no-self-use
         """Return decryption materials.
 
-        :param encryption_context: Encryption context for request
-        :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
+        :param EncryptionContext encryption_context: Encryption context for request
         :raises AttributeError: if no decryption materials are available
         """
         raise AttributeError('No decryption materials available')
@@ -36,8 +35,7 @@ class CryptographicMaterialsProvider(object):
         # pylint: disable=unused-argument,no-self-use
         """Return encryption materials.
 
-        :param encryption_context: Encryption context for request
-        :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
+        :param EncryptionContext encryption_context: Encryption context for request
         :raises AttributeError: if no encryption materials are available
         """
         raise AttributeError('No encryption materials available')

--- a/src/dynamodb_encryption_sdk/material_providers/most_recent.py
+++ b/src/dynamodb_encryption_sdk/material_providers/most_recent.py
@@ -43,6 +43,7 @@ _GRACE_PERIOD = 0.5
 
 class TtlActions(Enum):
     """Actions that can be taken based on the version TTl state."""
+
     EXPIRED = 0
     GRACE_PERIOD = 1
     LIVE = 2
@@ -99,7 +100,11 @@ class BasicCache(object):
 
     def get(self, name):
         # type: (Any) -> Any
-        """Get a value from the cache."""
+        """Get a value from the cache.
+
+        :param name: Object to identify the value in the cache
+        :returns: Value from cache
+        """
         with self._cache_lock:
             value = self._cache.pop(name)
             self.put(name, value)  # bump to the from of the LRU
@@ -120,8 +125,7 @@ class MostRecentProvider(CryptographicMaterialsProvider):
     When encrypting, the most recent provider that the provider store knows about will always
     be used.
 
-    :param provider_store: Provider store to use
-    :type provider_store: dynamodb_encryption_sdk.material_providers.store.ProviderStore
+    :param ProviderStore provider_store: Provider store to use
     :param str material_name: Name of materials for which to ask the provider store
     :param float version_ttl: Max time in seconds to go until checking with provider store
         for a more recent version
@@ -159,8 +163,7 @@ class MostRecentProvider(CryptographicMaterialsProvider):
         # type: (EncryptionContext) -> CryptographicMaterials
         """Return decryption materials.
 
-        :param encryption_context: Encryption context for request
-        :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
+        :param EncryptionContext encryption_context: Encryption context for request
         :raises AttributeError: if no decryption materials are available
         """
         version = self._provider_store.version_from_material_description(encryption_context.material_description)
@@ -266,8 +269,7 @@ class MostRecentProvider(CryptographicMaterialsProvider):
         # type: (EncryptionContext) -> CryptographicMaterials
         """Return encryption materials.
 
-        :param encryption_context: Encryption context for request
-        :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
+        :param EncryptionContext encryption_context: Encryption context for request
         :raises AttributeError: if no encryption materials are available
         """
         ttl_action = self._ttl_action()

--- a/src/dynamodb_encryption_sdk/material_providers/static.py
+++ b/src/dynamodb_encryption_sdk/material_providers/static.py
@@ -31,10 +31,8 @@ __all__ = ('StaticCryptographicMaterialsProvider',)
 class StaticCryptographicMaterialsProvider(CryptographicMaterialsProvider):
     """Manually combine encryption and decryption materials for use as a cryptographic materials provider.
 
-    :param decryption_materials: Decryption materials to provide (optional)
-    :type decryption_materials: dynamodb_encryption_sdk.materials.DecryptionMaterials
-    :param encryption_materials: Encryption materials to provide (optional)
-    :type encryption_materials: dynamodb_encryption_sdk.materials.EncryptionMaterials
+    :param DecryptionMaterials decryption_materials: Decryption materials to provide (optional)
+    :param EncryptionMaterials encryption_materials: Encryption materials to provide (optional)
     """
 
     _decryption_materials = attr.ib(
@@ -64,8 +62,8 @@ class StaticCryptographicMaterialsProvider(CryptographicMaterialsProvider):
         # type: (EncryptionContext) -> CryptographicMaterials
         """Return the static decryption materials.
 
-        :param encryption_context: Encryption context for request (not used by ``StaticCryptographicMaterialsProvider``)
-        :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
+        :param EncryptionContext encryption_context: Encryption context for request (not
+            used by :class:`StaticCryptographicMaterialsProvider`)
         :raises AttributeError: if no decryption materials are available
         """
         if self._decryption_materials is None:
@@ -77,8 +75,8 @@ class StaticCryptographicMaterialsProvider(CryptographicMaterialsProvider):
         # type: (EncryptionContext) -> CryptographicMaterials
         """Return the static encryption materials.
 
-        :param encryption_context: Encryption context for request (not used by ``StaticCryptographicMaterialsProvider``)
-        :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
+        :param EncryptionContext encryption_context: Encryption context for request (not
+            used by :class:`StaticCryptographicMaterialsProvider`)
         :raises AttributeError: if no encryption materials are available
         """
         if self._encryption_materials is None:

--- a/src/dynamodb_encryption_sdk/material_providers/store/__init__.py
+++ b/src/dynamodb_encryption_sdk/material_providers/store/__init__.py
@@ -21,8 +21,8 @@ except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
 
-from dynamodb_encryption_sdk.exceptions import InvalidVersionError, NoKnownVersionError
-from dynamodb_encryption_sdk.material_providers import CryptographicMaterialsProvider
+from dynamodb_encryption_sdk.exceptions import NoKnownVersionError
+from dynamodb_encryption_sdk.material_providers import CryptographicMaterialsProvider  # noqa pylint: disable=unused-import
 
 __all__ = ('ProviderStore',)
 
@@ -41,7 +41,7 @@ class ProviderStore(object):
         :param str material_name: Material to locate
         :param int version: Version of material to locate (optional)
         :returns: cryptographic materials provider
-        :rtype: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
+        :rtype: CryptographicMaterialsProvider
         :raises InvalidVersionError: if the requested version is not available and cannot be created
         """
 
@@ -66,7 +66,7 @@ class ProviderStore(object):
         :param str material_name: Material to locate
         :returns: Maximum known version
         :rtype: int
-        :raises NoKnownVersion: if no version can be found
+        :raises NoKnownVersionError: if no version can be found
         """
         raise NoKnownVersionError('No known version for name: "{}"'.format(material_name))
 
@@ -79,7 +79,7 @@ class ProviderStore(object):
         :param str material_name: Material to locate
         :param int version: Version of material to locate (optional)
         :returns: cryptographic materials provider
-        :rtype: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
+        :rtype: CryptographicMaterialsProvider
         :raises InvalidVersionError: if the requested version is not found
         """
         if version is None:
@@ -95,7 +95,7 @@ class ProviderStore(object):
 
         :param str material_name: Material to locate
         :returns: cryptographic materials provider
-        :rtype: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
+        :rtype: CryptographicMaterialsProvider
         """
         version = self.max_version(material_name) + 1
         return self.get_or_create_provider(material_name, version)

--- a/src/dynamodb_encryption_sdk/material_providers/store/meta.py
+++ b/src/dynamodb_encryption_sdk/material_providers/store/meta.py
@@ -68,8 +68,7 @@ class MetaStore(ProviderStore):
 
     :param table: Pre-configured boto3 DynamoDB Table object
     :type table: boto3.resources.base.ServiceResource
-    :param materials_provider: Cryptographic materials provider to use
-    :type materials_provider: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
+    :param CryptographicMaterialsProvider materials_provider: Cryptographic materials provider to use
     """
 
     _table = attr.ib(validator=attr.validators.instance_of(ServiceResource))
@@ -141,7 +140,7 @@ class MetaStore(ProviderStore):
         """Load materials from table.
 
         :returns: Materials loaded into delegated keys
-        :rtype: tuple of JceNameLocalDelegatedKey
+        :rtype: tuple(JceNameLocalDelegatedKey)
         """
         key = {
             MetaStoreAttributeNames.PARTITION.value: material_name,
@@ -223,10 +222,8 @@ class MetaStore(ProviderStore):
 
         :param str material_name: Material to locate
         :param int version: Version of material to locate
-        :param encryption_key: Loaded encryption key
-        :type encryption_key: dynamodb_encryption_sdk.delegated_keys.jce.JceNameLocalDelegatedKey
-        :param signing_key: Loaded signing key
-        :type signing_key: dynamodb_encryption_sdk.delegated_keys.jce.JceNameLocalDelegatedKey
+        :param JceNameLocalDelegatedKey encryption_key: Loaded encryption key
+        :param JceNameLocalDelegatedKey signing_key: Loaded signing key
         """
         try:
             self._save_materials(material_name, version, encryption_key, signing_key)
@@ -270,7 +267,7 @@ class MetaStore(ProviderStore):
         :param str material_name: Material to locate
         :param int version: Version of material to locate
         :returns: cryptographic materials provider
-        :rtype: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
+        :rtype: CryptographicMaterialsProvider
         :raises InvalidVersionError: if the requested version is not available and cannot be created
         """
         encryption_key = JceNameLocalDelegatedKey.generate(
@@ -300,7 +297,7 @@ class MetaStore(ProviderStore):
         :param str material_name: Material to locate
         :param int version: Version of material to locate (optional)
         :returns: cryptographic materials provider
-        :rtype: dynamodb_encryption_sdk.material_providers.CryptographicMaterialsProvider
+        :rtype: CryptographicMaterialsProvider
         :raises InvalidVersionError: if the requested version is not found
         """
         if version is not None:

--- a/src/dynamodb_encryption_sdk/material_providers/wrapped.py
+++ b/src/dynamodb_encryption_sdk/material_providers/wrapped.py
@@ -40,17 +40,14 @@ __all__ = ('WrappedCryptographicMaterialsProvider',)
 class WrappedCryptographicMaterialsProvider(CryptographicMaterialsProvider):
     """Cryptographic materials provider to use ephemeral content encryption keys wrapped by delegated keys.
 
-    :param signing_key: Delegated key used as signing and verification key
-    :type signing_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
-    :param wrapping_key: Delegated key used to wrap content key
-    :type wrapping_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+    :param DelegatedKey signing_key: Delegated key used as signing and verification key
+    :param DelegatedKey wrapping_key: Delegated key used to wrap content key
 
     .. note::
 
         ``wrapping_key`` must be provided if providing encryption materials
 
-    :param unwrapping_key: Delegated key used to unwrap content key
-    :type unwrapping_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+    :param DelegatedKey unwrapping_key: Delegated key used to unwrap content key
 
     .. note::
 
@@ -113,10 +110,9 @@ class WrappedCryptographicMaterialsProvider(CryptographicMaterialsProvider):
         # type: (EncryptionContext) -> WrappedCryptographicMaterials
         """Construct
 
-        :param encryption_context: Encryption context for request
-        :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
+        :param EncryptionContext encryption_context: Encryption context for request
         :returns: Wrapped cryptographic materials
-        :rtype: dynamodb_encryption_sdk.materials.wrapped.WrappedCryptographicMaterials
+        :rtype: WrappedCryptographicMaterials
         """
         material_description = self._material_description.copy()
         material_description.update(encryption_context.material_description)
@@ -131,10 +127,9 @@ class WrappedCryptographicMaterialsProvider(CryptographicMaterialsProvider):
         # type: (EncryptionContext) -> WrappedCryptographicMaterials
         """Provide encryption materials.
 
-        :param encryption_context: Encryption context for request
-        :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
+        :param EncryptionContext encryption_context: Encryption context for request
         :returns: Encryption materials
-        :rtype: dynamodb_encryption_sdk.materials.wrapped.WrappedCryptographicMaterials
+        :rtype: WrappedCryptographicMaterials
         :raises WrappingError: if no wrapping key is available
         """
         if self._wrapping_key is None:
@@ -146,10 +141,9 @@ class WrappedCryptographicMaterialsProvider(CryptographicMaterialsProvider):
         # type: (EncryptionContext) -> WrappedCryptographicMaterials
         """Provide decryption materials.
 
-        :param encryption_context: Encryption context for request
-        :type encryption_context: dynamodb_encryption_sdk.structures.EncryptionContext
+        :param EncryptionContext encryption_context: Encryption context for request
         :returns: Decryption materials
-        :rtype: dynamodb_encryption_sdk.materials.wrapped.WrappedCryptographicMaterials
+        :rtype: WrappedCryptographicMaterials
         :raises UnwrappingError: if no unwrapping key is available
         """
         if self._unwrapping_key is None:

--- a/src/dynamodb_encryption_sdk/materials/__init__.py
+++ b/src/dynamodb_encryption_sdk/materials/__init__.py
@@ -46,7 +46,7 @@ class CryptographicMaterials(object):
         """Delegated key used for encrypting attributes.
 
         :returns: Encryption key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
 
     @abc.abstractproperty
@@ -55,7 +55,7 @@ class CryptographicMaterials(object):
         """Delegated key used for decrypting attributes.
 
         :returns: Decryption key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
 
     @abc.abstractproperty
@@ -64,7 +64,7 @@ class CryptographicMaterials(object):
         """Delegated key used for calculating digital signatures.
 
         :returns: Signing key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
 
     @abc.abstractproperty
@@ -73,7 +73,7 @@ class CryptographicMaterials(object):
         """Delegated key used for verifying digital signatures.
 
         :returns: Verification key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
 
 

--- a/src/dynamodb_encryption_sdk/materials/raw.py
+++ b/src/dynamodb_encryption_sdk/materials/raw.py
@@ -49,10 +49,8 @@ class RawEncryptionMaterials(EncryptionMaterials):
 
         Not all delegated keys allow use with raw cryptographic materials.
 
-    :param signing_key: Delegated key used as signing key
-    :type signing_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
-    :param encryption_key: Delegated key used as encryption key
-    :type encryption_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+    :param DelegatedKey signing_key: Delegated key used as signing key
+    :param DelegatedKey encryption_key: Delegated key used as encryption key
     :param dict material_description: Material description to use with these cryptographic materials
     """
 
@@ -110,7 +108,7 @@ class RawEncryptionMaterials(EncryptionMaterials):
         """Delegated key used for calculating digital signatures.
 
         :returns: Signing key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         return self._signing_key
 
@@ -120,7 +118,7 @@ class RawEncryptionMaterials(EncryptionMaterials):
         """Delegated key used for encrypting attributes.
 
         :returns: Encryption key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         if self._encryption_key is None:
             raise AttributeError('No encryption key available')
@@ -137,10 +135,8 @@ class RawDecryptionMaterials(DecryptionMaterials):
 
         Not all delegated keys allow use with raw cryptographic materials.
 
-    :param verification_key: Delegated key used as verification key
-    :type verification_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
-    :param decryption_key: Delegated key used as decryption key
-    :type decryption_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+    :param DelegatedKey verification_key: Delegated key used as verification key
+    :param DelegatedKey decryption_key: Delegated key used as decryption key
     :param dict material_description: Material description to use with these cryptographic materials
     """
 
@@ -198,7 +194,7 @@ class RawDecryptionMaterials(DecryptionMaterials):
         """Delegated key used for verifying digital signatures.
 
         :returns: Verification key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         return self._verification_key
 
@@ -208,7 +204,7 @@ class RawDecryptionMaterials(DecryptionMaterials):
         """Delegated key used for decrypting attributes.
 
         :returns: Decryption key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         if self._decryption_key is None:
             raise AttributeError('No decryption key available')

--- a/src/dynamodb_encryption_sdk/materials/wrapped.py
+++ b/src/dynamodb_encryption_sdk/materials/wrapped.py
@@ -44,17 +44,14 @@ class WrappedCryptographicMaterials(CryptographicMaterials):
     """Encryption/decryption key is a content key stored in the material description, wrapped
     by the wrapping key.
 
-    :param signing_key: Delegated key used as signing and verification key
-    :type signing_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
-    :param wrapping_key: Delegated key used to wrap content key
-    :type wrapping_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+    :param DelegatedKey signing_key: Delegated key used as signing and verification key
+    :param DelegatedKey wrapping_key: Delegated key used to wrap content key
 
     .. note::
 
         ``wrapping_key`` must be provided if material description contains a wrapped content key
 
-    :param unwrapping_key: Delegated key used to unwrap content key
-    :type unwrapping_key: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+    :param DelegatedKey unwrapping_key: Delegated key used to unwrap content key
 
     .. note::
 
@@ -126,7 +123,7 @@ class WrappedCryptographicMaterials(CryptographicMaterials):
         """Load the content key from material description and unwrap it for use.
 
         :returns: Unwrapped content key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         if self._unwrapping_key is None:
             raise UnwrappingError(
@@ -154,7 +151,7 @@ class WrappedCryptographicMaterials(CryptographicMaterials):
         necessary information about the content and wrapping keys.
 
         :returns content key and new material description
-        :rtype: tuple containing dynamodb_encryption_sdk.delegated_keys.DelegatedKey and dict
+        :rtype: tuple containing DelegatedKey and dict
         """
         if self._wrapping_key is None:
             raise WrappingError('Cryptographic materials cannot be generated: no wrapping key')
@@ -201,7 +198,7 @@ class WrappedCryptographicMaterials(CryptographicMaterials):
         """Content key used for encrypting attributes.
 
         :returns: Encryption key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         return self._content_key
 
@@ -210,7 +207,7 @@ class WrappedCryptographicMaterials(CryptographicMaterials):
         """Content key used for decrypting attributes.
 
         :returns: Decryption key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         return self._content_key
 
@@ -219,7 +216,7 @@ class WrappedCryptographicMaterials(CryptographicMaterials):
         """Delegated key used for calculating digital signatures.
 
         :returns: Signing key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         return self._signing_key
 
@@ -228,6 +225,6 @@ class WrappedCryptographicMaterials(CryptographicMaterials):
         """Delegated key used for verifying digital signatures.
 
         :returns: Verification key
-        :rtype: dynamodb_encryption_sdk.delegated_keys.DelegatedKey
+        :rtype: DelegatedKey
         """
         return self._signing_key

--- a/src/dynamodb_encryption_sdk/structures.py
+++ b/src/dynamodb_encryption_sdk/structures.py
@@ -111,8 +111,8 @@ class EncryptionContext(object):
 class AttributeActions(object):
     """Configuration resource used to determine what action should be taken for a specific attribute.
 
-    :param default_action: Action to take if no specific action is defined in ``attribute_actions``
-    :type default_action: dynamodb_encryption_sdk.identifiers.CryptoAction
+    :param CryptoAction default_action: Action to take if no specific action is defined in
+        ``attribute_actions``
     :param dict attribute_actions: Dictionary mapping attribute names to specific actions
     """
 
@@ -158,7 +158,11 @@ class AttributeActions(object):
 
     def action(self, attribute_name):
         # (text) -> CryptoAction
-        """Determine the correct CryptoAction to apply to a supplied attribute based on this config."""
+        """Determine the correct :class:`CryptoAction` to apply to a supplied attribute based
+        on this config.
+
+        :param str attribute_name: Attribute for which to determine action
+        """
         return self.attribute_actions.get(attribute_name, self.default_action)
 
     def copy(self):
@@ -177,9 +181,13 @@ class AttributeActions(object):
             If you have already set a custom action for any of these attributes, this will
             raise an error.
 
-        DO_NOTHING -> DO_NOTHING
-        SIGN_ONLY -> SIGN_ONLY
-        ENCRYPT_AND_SIGN -> SIGN_ONLY
+        .. code::
+
+            Default Action   -> Index Key Action
+            DO_NOTHING       -> DO_NOTHING
+            SIGN_ONLY        -> SIGN_ONLY
+            ENCRYPT_AND_SIGN -> SIGN_ONLY
+
         :param str *keys: Attribute names to treat as indexed
         :raises InvalidArgumentError: if a custom action was previously set for any specified
             attributes
@@ -198,8 +206,7 @@ class AttributeActions(object):
         # (CryptoAction) -> bool
         """Determine if the specified action is a possible action from this configuration.
 
-        :param action: Action to look for
-        :type action: dynamodb_encryption_sdk.identifiers.CryptoAction
+        :param CryptoAction action: Action to look for
         """
         return action is self.default_action or action in self.attribute_actions.values()
 
@@ -260,16 +267,18 @@ class TableIndex(object):
         # type: (Iterable[Dict[Text, Text]]) -> TableIndex
         """Build a TableIndex from the key schema returned by DescribeTable.
 
-        [
-            {
-                "KeyType": "HASH"|"RANGE",
-                "AttributeName": ""
-            },
-        ]
+        .. code::
+
+            [
+                {
+                    "KeyType": "HASH"|"RANGE",
+                    "AttributeName": ""
+                },
+            ]
 
         :param list key_schema: KeySchema from DescribeTable response
         :returns: New TableIndex that describes the provided schema
-        :rtype: dynamodb_encryption_sdk.structures.TableIndex
+        :rtype: TableIndex
         """
         index = {
             key['KeyType']: key['AttributeName']
@@ -287,10 +296,9 @@ class TableInfo(object):
 
     :param str name: Table name
     :param bool all_encrypting_secondary_indexes: Should we allow secondary index attributes to be encrypted?
-    :param primary_index: Description of primary index
-    :type primary_index: dynamodb_encryption_sdk.structures.TableIndex
+    :param TableIndex primary_index: Description of primary index
     :param secondary_indexes: Set of TableIndex objects describing any secondary indexes
-    :type secondary_indexes: set of dynamodb_encryption_sdk.structures.TableIndex
+    :type secondary_indexes: set(TableIndex)
     """
 
     name = attr.ib(validator=attr.validators.instance_of(six.string_types))


### PR DESCRIPTION
*Description of changes:*
When I started going through the rendered docs, I realized that Sphinx does not require the full namespace path for custom classes if those classes are defined in this codebase. In light of that, this replaces all of those full namespace paths with just the class name. This results in a much cleaner, more concise, rendered result that still links to the docs for that class.

Note about the change in `conf.py`: this is just updating the template that I had started with to a more modern syntax for `intersphinx_mapping`.
http://www.sphinx-doc.org/en/1.5.1/ext/intersphinx.html#confval-intersphinx_mapping

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
