### PR TITLE
pin botocore and boto3 in tests https://github.com/spulec/moto/issues/1793

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -7,5 +7,6 @@ pytest-mock
 pytest-xdist
 # temporarily pinning boto3 and botocore because the new version broke moto
 # https://github.com/spulec/moto/issues/1793
+# proper fix TBD https://github.com/aws/aws-dynamodb-encryption-python/issues/85
 boto3 < 1.8.0
 botocore < 1.11.0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,3 +5,7 @@ pytest>=3.3.1
 pytest-cov
 pytest-mock
 pytest-xdist
+# temporarily pinning boto3 and botocore because the new version broke moto
+# https://github.com/spulec/moto/issues/1793
+boto3 < 1.8.0
+botocore < 1.11.0


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/spulec/moto/issues/1793
https://github.com/pyca/cryptography/issues/4415

*Description of changes:*
This is a temporary fix to unblock pyca/cryptography. We need to properly fix this #85 but that problem ended up being more complex that I had anticipated due to pip's behavior of hard equalities overriding the 'ignore if present' directive. This fix will unblock the immediate issue and we can then move forward for finding the best long-term solution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
