### PR TITLE
remove use of deprecated hypothesis features

### DIFF
--- a/test/functional/hypothesis_strategies.py
+++ b/test/functional/hypothesis_strategies.py
@@ -25,10 +25,9 @@ SLOW_SETTINGS = hypothesis.settings(
         hypothesis.HealthCheck.hung_test,
         hypothesis.HealthCheck.large_base_example,
     ),
-    timeout=hypothesis.unlimited,
     deadline=None,
 )
-VERY_SLOW_SETTINGS = hypothesis.settings(SLOW_SETTINGS, max_examples=1000, max_iterations=1500)
+VERY_SLOW_SETTINGS = hypothesis.settings(SLOW_SETTINGS, max_examples=1000)
 MAX_ITEM_BYTES = 400 * 1024 * 1024
 
 # _MIN_NUMBER = Decimal('1E-128')  # The DDB min is 1E-130, but DYNAMODB_CONTEXT Emin is -128

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
-hypothesis==3.63.0
+hypothesis>=3.63.0
 mock
 # temporarily pinning moto pending resolution of
 # https://github.com/spulec/moto/issues/1924


### PR DESCRIPTION
*Description of changes:*

* timeout: https://hypothesis.readthedocs.io/en/master/changes.html#v3-16-0
* max_iterations: https://hypothesis.readthedocs.io/en/master/changes.html#v3-56-0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
