### PR TITLE
Actually fix MostRecentProvider reuse bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+1.0.7 -- 2018-01-xx
+===================
+
+Bugfixes
+--------
+* Fix :class:`MostRecentProvider` cache reuse bug.
+  `#105 <https://github.com/aws/aws-dynamodb-encryption-python/pull/105>`_
+
 1.0.6 -- 2018-01-15
 ===================
 

--- a/src/dynamodb_encryption_sdk/encrypted/item.py
+++ b/src/dynamodb_encryption_sdk/encrypted/item.py
@@ -70,7 +70,6 @@ def encrypt_dynamodb_item(item, crypto_config):
                 'Reserved attribute name "{}" is not allowed in plaintext item.'.format(reserved_name.value)
             )
 
-    crypto_config.materials_provider.refresh()
     encryption_materials = crypto_config.encryption_materials()
 
     inner_material_description = encryption_materials.material_description.copy()

--- a/src/dynamodb_encryption_sdk/internal/utils.py
+++ b/src/dynamodb_encryption_sdk/internal/utils.py
@@ -59,10 +59,8 @@ class TableInfoCache(object):
     _client = attr.ib(validator=attr.validators.instance_of(botocore.client.BaseClient))
     _auto_refresh_table_indexes = attr.ib(validator=attr.validators.instance_of(bool))
 
-    def __init__(
-        self, client, auto_refresh_table_indexes  # type: botocore.client.BaseClient  # type: bool
-    ):  # noqa=D107
-        # type: (...) -> None
+    def __init__(self, client, auto_refresh_table_indexes):  # noqa=D107
+        # type: (botocore.client.BaseClient, bool) -> None
         # Workaround pending resolution of attrs/mypy interaction.
         # https://github.com/python/mypy/issues/2088
         # https://github.com/python-attrs/attrs/issues/215

--- a/src/dynamodb_encryption_sdk/material_providers/most_recent.py
+++ b/src/dynamodb_encryption_sdk/material_providers/most_recent.py
@@ -112,6 +112,7 @@ class BasicCache(object):
     def clear(self):
         # type: () -> None
         """Clear the cache."""
+        _LOGGER.debug("Clearing cache")
         with self._cache_lock:
             self._cache = OrderedDict()  # type: OrderedDict[Any, Any] # pylint: disable=attribute-defined-outside-init
 
@@ -163,8 +164,10 @@ class MostRecentProvider(CryptographicMaterialsProvider):
         """
         version = self._provider_store.version_from_material_description(encryption_context.material_description)
         try:
+            _LOGGER.debug("Looking in cache for decryption materials provider version %d", version)
             provider = self._cache.get(version)
         except KeyError:
+            _LOGGER.debug("Decryption materials provider not found in cache")
             try:
                 provider = self._provider_store.provider(self._material_name, version)
             except InvalidVersionError:
@@ -281,10 +284,10 @@ class MostRecentProvider(CryptographicMaterialsProvider):
 
         if ttl_action is TtlActions.LIVE:
             try:
-                _LOGGER.debug("Looking in cache for materials provider version %d", self._version)
+                _LOGGER.debug("Looking in cache for encryption materials provider version %d", self._version)
                 provider = self._cache.get(self._version)
             except KeyError:
-                _LOGGER.debug("Provider not found in cache")
+                _LOGGER.debug("Encryption materials provider not found in cache")
                 ttl_action = TtlActions.EXPIRED
 
         if provider is None:

--- a/src/dynamodb_encryption_sdk/material_providers/store/meta.py
+++ b/src/dynamodb_encryption_sdk/material_providers/store/meta.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Meta cryptographic provider store."""
+import logging
 from enum import Enum
 
 import attr
@@ -22,7 +23,7 @@ from boto3.resources.base import ServiceResource
 from dynamodb_encryption_sdk.delegated_keys.jce import JceNameLocalDelegatedKey
 from dynamodb_encryption_sdk.encrypted.table import EncryptedTable
 from dynamodb_encryption_sdk.exceptions import InvalidVersionError, NoKnownVersionError, VersionAlreadyExistsError
-from dynamodb_encryption_sdk.identifiers import EncryptionKeyType, KeyEncodingType
+from dynamodb_encryption_sdk.identifiers import LOGGER_NAME, EncryptionKeyType, KeyEncodingType
 from dynamodb_encryption_sdk.material_providers import CryptographicMaterialsProvider
 from dynamodb_encryption_sdk.material_providers.wrapped import WrappedCryptographicMaterialsProvider
 

--- a/src/dynamodb_encryption_sdk/material_providers/store/meta.py
+++ b/src/dynamodb_encryption_sdk/material_providers/store/meta.py
@@ -36,6 +36,7 @@ except ImportError:  # pragma: no cover
 
 
 __all__ = ("MetaStore",)
+_LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 class MetaStoreAttributeNames(Enum):
@@ -104,6 +105,7 @@ class MetaStore(ProviderStore):
         :param int read_units: Read capacity units to provision
         :param int write_units: Write capacity units to provision
         """
+        _LOGGER.debug("Creating MetaStore table")
         try:
             client.create_table(
                 TableName=table_name,
@@ -127,6 +129,7 @@ class MetaStore(ProviderStore):
         :returns: Materials loaded into delegated keys
         :rtype: tuple(JceNameLocalDelegatedKey)
         """
+        _LOGGER.debug('Loading material "%s" version %d from MetaStore table', material_name, version)
         key = {MetaStoreAttributeNames.PARTITION.value: material_name, MetaStoreAttributeNames.SORT.value: version}
         response = self._encrypted_table.get_item(Key=key)
         try:
@@ -168,6 +171,7 @@ class MetaStore(ProviderStore):
         :param int version: Version of material to locate
         :raises VersionAlreadyExistsError: if the specified version already exists
         """
+        _LOGGER.debug('Saving material "%s" version %d to MetaStore table', material_name, version)
         item = {
             MetaStoreAttributeNames.PARTITION.value: material_name,
             MetaStoreAttributeNames.SORT.value: version,

--- a/test/functional/functional_test_utils.py
+++ b/test/functional/functional_test_utils.py
@@ -701,10 +701,7 @@ def check_metastore_cache_use_encrypt(metastore, table_name, log_capture):
     table = boto3.resource("dynamodb").Table(table_name)
 
     most_recent_provider = MostRecentProvider(provider_store=metastore, material_name="test", version_ttl=600.0)
-    e_table = EncryptedTable(
-        table=table,
-        materials_provider=most_recent_provider,
-    )
+    e_table = EncryptedTable(table=table, materials_provider=most_recent_provider)
 
     item = diverse_item()
     item.update(TEST_KEY)

--- a/test/functional/material_providers/test_most_recent.py
+++ b/test/functional/material_providers/test_most_recent.py
@@ -21,6 +21,9 @@ from dynamodb_encryption_sdk.material_providers import CryptographicMaterialsPro
 from dynamodb_encryption_sdk.material_providers.most_recent import MostRecentProvider
 from dynamodb_encryption_sdk.material_providers.store import ProviderStore
 
+from ..functional_test_utils import mock_metastore, example_table  # pylint: disable=unused-import
+from ..functional_test_utils import TEST_TABLE_NAME, check_metastore_cache_use_encrypt
+
 pytestmark = [pytest.mark.functional, pytest.mark.local]
 
 
@@ -130,3 +133,7 @@ def test_decryption_materials_cache_use():
     expected_calls.append(("version_from_material_description", 0))
 
     assert store.provider_calls == expected_calls
+
+
+def test_cache_use_encrypt(mock_metastore, example_table, caplog):
+    check_metastore_cache_use_encrypt(mock_metastore, TEST_TABLE_NAME, caplog)

--- a/test/functional/material_providers/test_most_recent.py
+++ b/test/functional/material_providers/test_most_recent.py
@@ -21,8 +21,12 @@ from dynamodb_encryption_sdk.material_providers import CryptographicMaterialsPro
 from dynamodb_encryption_sdk.material_providers.most_recent import MostRecentProvider
 from dynamodb_encryption_sdk.material_providers.store import ProviderStore
 
-from ..functional_test_utils import mock_metastore, example_table  # pylint: disable=unused-import
-from ..functional_test_utils import TEST_TABLE_NAME, check_metastore_cache_use_encrypt
+from ..functional_test_utils import (  # pylint: disable=unused-import
+    TEST_TABLE_NAME,
+    check_metastore_cache_use_encrypt,
+    example_table,
+    mock_metastore,
+)
 
 pytestmark = [pytest.mark.functional, pytest.mark.local]
 

--- a/test/functional/test_structures.py
+++ b/test/functional/test_structures.py
@@ -22,7 +22,7 @@ from .functional_test_utils import (
     TEST_TABLE_NAME,
     example_table,
     table_with_global_secondary_indexes,
-    table_with_local_seconary_indexes,
+    table_with_local_secondary_indexes,
 )
 
 pytestmark = [pytest.mark.functional, pytest.mark.local]
@@ -37,14 +37,14 @@ def test_tableinfo_refresh_indexes_no_secondary_indexes(example_table):
     table.refresh_indexed_attributes(client)
 
 
-def test_tableinfo_refresh_indexes_with_gsis(table_with_global_seconary_indexes):
+def test_tableinfo_refresh_indexes_with_gsis(table_with_global_secondary_indexes):
     client = boto3.client("dynamodb", region_name="us-west-2")
     table = TableInfo(name=TEST_TABLE_NAME)
 
     table.refresh_indexed_attributes(client)
 
 
-def test_tableinfo_refresh_indexes_with_lsis(table_with_local_seconary_indexes):
+def test_tableinfo_refresh_indexes_with_lsis(table_with_local_secondary_indexes):
     client = boto3.client("dynamodb", region_name="us-west-2")
     table = TableInfo(name=TEST_TABLE_NAME)
 

--- a/test/functional/test_structures.py
+++ b/test/functional/test_structures.py
@@ -21,7 +21,7 @@ from dynamodb_encryption_sdk.structures import AttributeActions, TableIndex, Tab
 from .functional_test_utils import (
     TEST_TABLE_NAME,
     example_table,
-    table_with_global_seconary_indexes,
+    table_with_global_secondary_indexes,
     table_with_local_seconary_indexes,
 )
 

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -69,4 +69,6 @@ def ddb_table_name():
 
 @pytest.fixture
 def temp_metastore():
-    yield next(functional_test_utils.build_metastore())
+    metastore, table_name = functional_test_utils.build_metastore()
+    yield metastore
+    functional_test_utils.delete_metastore(table_name)

--- a/test/integration/material_providers/store/test_meta.py
+++ b/test/integration/material_providers/store/test_meta.py
@@ -11,9 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Integration tests for ``dynamodb_encryption_sdk.material_providers.store.meta``."""
-import os
-
-import boto3
 import pytest
 
 from dynamodb_encryption_sdk.exceptions import NoKnownVersionError

--- a/test/integration/material_providers/test_most_recent.py
+++ b/test/integration/material_providers/test_most_recent.py
@@ -15,9 +15,9 @@ import pytest
 
 from ..integration_test_utils import (  # pylint: disable=unused-import
     ddb_table_name,
+    functional_test_utils,
     temp_metastore,
 )
-from ..integration_test_utils import functional_test_utils
 
 pytestmark = [pytest.mark.integ, pytest.mark.ddb_integ]
 

--- a/test/integration/material_providers/test_most_recent.py
+++ b/test/integration/material_providers/test_most_recent.py
@@ -11,58 +11,16 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Load testing using MostRecentProvider and MetaStore."""
-import boto3
 import pytest
-
-from dynamodb_encryption_sdk.encrypted.table import EncryptedTable
-from dynamodb_encryption_sdk.material_providers.most_recent import MostRecentProvider
 
 from ..integration_test_utils import (  # pylint: disable=unused-import
     ddb_table_name,
-    functional_test_utils,
     temp_metastore,
 )
+from ..integration_test_utils import functional_test_utils
 
 pytestmark = [pytest.mark.integ, pytest.mark.ddb_integ]
 
 
-def count_entries(records, *messages):
-    count = 0
-
-    for record in records:
-        if all((message in record.getMessage() for message in messages)):
-            count += 1
-
-    return count
-
-
-def count_puts(records, table_name):
-    return count_entries(records, '"TableName": "{}"'.format(table_name), "OperationModel(name=PutItem)")
-
-
-def count_gets(records, table_name):
-    return count_entries(records, '"TableName": "{}"'.format(table_name), "OperationModel(name=GetItem)")
-
-
 def test_cache_use_encrypt(temp_metastore, ddb_table_name, caplog):
-    table = boto3.resource("dynamodb").Table(ddb_table_name)
-
-    e_table = EncryptedTable(
-        table=table,
-        materials_provider=MostRecentProvider(provider_store=temp_metastore, material_name="test", version_ttl=600.0),
-    )
-
-    item = functional_test_utils.diverse_item()
-    item.update(functional_test_utils.TEST_KEY)
-    e_table.put_item(Item=item)
-    e_table.put_item(Item=item)
-    e_table.put_item(Item=item)
-    e_table.put_item(Item=item)
-
-    e_table.delete_item(Key=functional_test_utils.TEST_KEY)
-
-    primary_puts = count_puts(caplog.records, ddb_table_name)
-    metastore_puts = count_puts(caplog.records, temp_metastore._table.name)
-
-    assert primary_puts == 4
-    assert metastore_puts == 1
+    functional_test_utils.check_metastore_cache_use_encrypt(temp_metastore, ddb_table_name, caplog)

--- a/test/integration/material_providers/test_most_recent.py
+++ b/test/integration/material_providers/test_most_recent.py
@@ -1,0 +1,68 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Load testing using MostRecentProvider and MetaStore."""
+import boto3
+import pytest
+
+from dynamodb_encryption_sdk.encrypted.table import EncryptedTable
+from dynamodb_encryption_sdk.material_providers.most_recent import MostRecentProvider
+
+from ..integration_test_utils import (  # pylint: disable=unused-import
+    ddb_table_name,
+    functional_test_utils,
+    temp_metastore,
+)
+
+pytestmark = [pytest.mark.integ, pytest.mark.ddb_integ]
+
+
+def count_entries(records, *messages):
+    count = 0
+
+    for record in records:
+        if all((message in record.getMessage() for message in messages)):
+            count += 1
+
+    return count
+
+
+def count_puts(records, table_name):
+    return count_entries(records, '"TableName": "{}"'.format(table_name), "OperationModel(name=PutItem)")
+
+
+def count_gets(records, table_name):
+    return count_entries(records, '"TableName": "{}"'.format(table_name), "OperationModel(name=GetItem)")
+
+
+def test_cache_use_encrypt(temp_metastore, ddb_table_name, caplog):
+    table = boto3.resource("dynamodb").Table(ddb_table_name)
+
+    e_table = EncryptedTable(
+        table=table,
+        materials_provider=MostRecentProvider(provider_store=temp_metastore, material_name="test", version_ttl=600.0),
+    )
+
+    item = functional_test_utils.diverse_item()
+    item.update(functional_test_utils.TEST_KEY)
+    e_table.put_item(Item=item)
+    e_table.put_item(Item=item)
+    e_table.put_item(Item=item)
+    e_table.put_item(Item=item)
+
+    e_table.delete_item(Key=functional_test_utils.TEST_KEY)
+
+    primary_puts = count_puts(caplog.records, ddb_table_name)
+    metastore_puts = count_puts(caplog.records, temp_metastore._table.name)
+
+    assert primary_puts == 4
+    assert metastore_puts == 1


### PR DESCRIPTION
*Description of changes:*
After #102 failed to fix the bug that the customer was seeing in cache use, digging into this deeper I found that the `encrypt_ddb_item` function was calling `.refresh()` on the crypto materials provider every pass. That component was not supposed to ever use that interface.

Also included here is additional logging since we didn't have much of any in either `MetaStore` or `MostRecentProvider`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
