### PR TITLE
Handle unprocessed items in batch write responses

### DIFF
--- a/test/functional/encrypted/test_client.py
+++ b/test/functional/encrypted/test_client.py
@@ -17,6 +17,8 @@ import pytest
 from ..functional_test_utils import example_table  # noqa pylint: disable=unused-import
 from ..functional_test_utils import (
     TEST_TABLE_NAME,
+    build_static_jce_cmp,
+    client_batch_items_unprocessed_check,
     client_cycle_batch_items_check,
     client_cycle_batch_items_check_paginators,
     client_cycle_single_item_check,
@@ -53,6 +55,12 @@ def _client_cycle_batch_items_check_paginators(materials_provider, initial_actio
     )
 
 
+def _client_batch_items_unprocessed_check(materials_provider, initial_actions, initial_item):
+    client_batch_items_unprocessed_check(
+        materials_provider, initial_actions, initial_item, TEST_TABLE_NAME, "us-west-2"
+    )
+
+
 def test_ephemeral_item_cycle(example_table, some_cmps, parametrized_actions, parametrized_item):
     """Test a small number of curated CMPs against a small number of curated items."""
     _client_cycle_single_item_check(some_cmps, parametrized_actions, parametrized_item)
@@ -66,6 +74,12 @@ def test_ephemeral_batch_item_cycle(example_table, some_cmps, parametrized_actio
 def test_ephemeral_batch_item_cycle_paginators(example_table, some_cmps, parametrized_actions, parametrized_item):
     """Test a small number of curated CMPs against a small number of curated items using paginators."""
     _client_cycle_batch_items_check_paginators(some_cmps, parametrized_actions, parametrized_item)
+
+
+def test_batch_item_unprocessed(example_table, parametrized_actions, parametrized_item):
+    """Test Unprocessed Items handling with a single ephemeral static CMP against a small number of curated items."""
+    cmp = build_static_jce_cmp("AES", 256, "HmacSHA256", 256)
+    _client_batch_items_unprocessed_check(cmp, parametrized_actions, parametrized_item)
 
 
 @pytest.mark.slow

--- a/test/functional/encrypted/test_resource.py
+++ b/test/functional/encrypted/test_resource.py
@@ -13,7 +13,7 @@
 """Functional tests for ``dynamodb_encryption_sdk.encrypted.resource``."""
 import pytest
 
-from ..functional_test_utils import example_table # noqa pylint: disable=unused-import
+from ..functional_test_utils import example_table  # noqa pylint: disable=unused-import
 from ..functional_test_utils import (
     TEST_TABLE_NAME,
     build_static_jce_cmp,

--- a/test/functional/encrypted/test_resource.py
+++ b/test/functional/encrypted/test_resource.py
@@ -13,9 +13,11 @@
 """Functional tests for ``dynamodb_encryption_sdk.encrypted.resource``."""
 import pytest
 
-from ..functional_test_utils import example_table  # noqa pylint: disable=unused-import
+from ..functional_test_utils import example_table # noqa pylint: disable=unused-import
 from ..functional_test_utils import (
     TEST_TABLE_NAME,
+    build_static_jce_cmp,
+    resource_batch_items_unprocessed_check,
     resource_cycle_batch_items_check,
     set_parametrized_actions,
     set_parametrized_cmp,
@@ -35,9 +37,22 @@ def _resource_cycle_batch_items_check(materials_provider, initial_actions, initi
     resource_cycle_batch_items_check(materials_provider, initial_actions, initial_item, TEST_TABLE_NAME, "us-west-2")
 
 
+def _resource_batch_items_unprocessed_check(materials_provider, initial_actions, initial_item):
+    resource_batch_items_unprocessed_check(
+        materials_provider, initial_actions, initial_item, TEST_TABLE_NAME, "us-west-2"
+    )
+
+
 def test_ephemeral_batch_item_cycle(example_table, some_cmps, parametrized_actions, parametrized_item):
     """Test a small number of curated CMPs against a small number of curated items."""
     _resource_cycle_batch_items_check(some_cmps, parametrized_actions, parametrized_item)
+
+
+def test_batch_item_unprocessed(example_table, parametrized_actions, parametrized_item):
+    """Test Unprocessed Items handling with a single ephemeral static CMP against a small number of curated items."""
+    _resource_batch_items_unprocessed_check(
+        build_static_jce_cmp("AES", 256, "HmacSHA256", 256), parametrized_actions, parametrized_item
+    )
 
 
 @pytest.mark.travis_isolation

--- a/test/functional/encrypted/test_table.py
+++ b/test/functional/encrypted/test_table.py
@@ -14,7 +14,7 @@
 import hypothesis
 import pytest
 
-from ..functional_test_utils import example_table # noqa pylint: disable=unused-import
+from ..functional_test_utils import example_table  # noqa pylint: disable=unused-import
 from ..functional_test_utils import (
     TEST_TABLE_NAME,
     build_static_jce_cmp,

--- a/test/functional/encrypted/test_table.py
+++ b/test/functional/encrypted/test_table.py
@@ -14,12 +14,14 @@
 import hypothesis
 import pytest
 
-from ..functional_test_utils import example_table  # noqa pylint: disable=unused-import
+from ..functional_test_utils import example_table # noqa pylint: disable=unused-import
 from ..functional_test_utils import (
     TEST_TABLE_NAME,
+    build_static_jce_cmp,
     set_parametrized_actions,
     set_parametrized_cmp,
     set_parametrized_item,
+    table_batch_writer_unprocessed_items_check,
     table_cycle_batch_writer_check,
     table_cycle_check,
 )
@@ -46,6 +48,14 @@ def test_ephemeral_item_cycle(example_table, some_cmps, parametrized_actions, pa
 def test_ephemeral_item_cycle_batch_writer(example_table, some_cmps, parametrized_actions, parametrized_item):
     """Test a small number of curated CMPs against a small number of curated items."""
     table_cycle_batch_writer_check(some_cmps, parametrized_actions, parametrized_item, TEST_TABLE_NAME, "us-west-2")
+
+
+def test_batch_writer_unprocessed(example_table, parametrized_actions, parametrized_item):
+    """Test Unprocessed Items handling with a single ephemeral static CMP against a small number of curated items."""
+    cmp = build_static_jce_cmp("AES", 256, "HmacSHA256", 256)
+    table_batch_writer_unprocessed_items_check(
+        cmp, parametrized_actions, parametrized_item, TEST_TABLE_NAME, "us-west-2"
+    )
 
 
 @pytest.mark.slow

--- a/test/functional/functional_test_utils.py
+++ b/test/functional/functional_test_utils.py
@@ -338,9 +338,7 @@ _reserved_attributes = set([attr.value for attr in ReservedAttributes])
 
 
 def return_requestitems_as_unprocessed(*args, **kwargs):
-    return {
-        "UnprocessedItems": kwargs['RequestItems']
-    }
+    return {"UnprocessedItems": kwargs["RequestItems"]}
 
 
 def check_encrypted_item(plaintext_item, ciphertext_item, attribute_actions):
@@ -495,10 +493,7 @@ def cycle_batch_writer_check(raw_table, encrypted_table, initial_actions, initia
 
 
 def batch_write_item_unprocessed_check(
-    encrypted,
-    initial_item,
-    write_transformer=_nop_transformer,
-    table_name=TEST_TABLE_NAME,
+    encrypted, initial_item, write_transformer=_nop_transformer, table_name=TEST_TABLE_NAME
 ):
     """Check that unprocessed items in a batch result are unencrypted."""
     items = _generate_items(initial_item, write_transformer)
@@ -565,11 +560,7 @@ def table_cycle_batch_writer_check(materials_provider, initial_actions, initial_
 
 
 def table_batch_writer_unprocessed_items_check(
-    materials_provider,
-    initial_actions,
-    initial_item,
-    table_name,
-    region_name=None
+    materials_provider, initial_actions, initial_item, table_name, region_name=None
 ):
     kwargs = {}
     if region_name is not None:
@@ -582,7 +573,7 @@ def table_batch_writer_unprocessed_items_check(
 
     with patch.object(table.meta.client, "batch_write_item") as batch_write_mock:
         # Check that unprocessed items returned to a BatchWriter are successfully retried
-        batch_write_mock.side_effect = [{"UnprocessedItems": request_items}, {'UnprocessedItems': {}}]
+        batch_write_mock.side_effect = [{"UnprocessedItems": request_items}, {"UnprocessedItems": {}}]
         e_table = EncryptedTable(table=table, materials_provider=materials_provider, attribute_actions=initial_actions)
 
         with e_table.batch_writer() as writer:
@@ -616,16 +607,12 @@ def resource_cycle_batch_items_check(materials_provider, initial_actions, initia
 
 
 def resource_batch_items_unprocessed_check(
-    materials_provider,
-    initial_actions,
-    initial_item,
-    table_name,
-    region_name=None
+    materials_provider, initial_actions, initial_item, table_name, region_name=None
 ):
     kwargs = {}
     if region_name is not None:
         kwargs["region_name"] = region_name
-    resource = boto3.resource('dynamodb', **kwargs)
+    resource = boto3.resource("dynamodb", **kwargs)
 
     with patch.object(resource, "batch_write_item", return_requestitems_as_unprocessed):
         e_resource = EncryptedResource(
@@ -633,10 +620,7 @@ def resource_batch_items_unprocessed_check(
         )
 
         batch_write_item_unprocessed_check(
-            encrypted=e_resource,
-            initial_item=initial_item,
-            write_transformer=dict_to_ddb,
-            table_name=table_name,
+            encrypted=e_resource, initial_item=initial_item, write_transformer=dict_to_ddb, table_name=table_name
         )
 
 
@@ -691,16 +675,12 @@ def client_cycle_batch_items_check(materials_provider, initial_actions, initial_
 
 
 def client_batch_items_unprocessed_check(
-    materials_provider,
-    initial_actions,
-    initial_item,
-    table_name,
-    region_name=None
+    materials_provider, initial_actions, initial_item, table_name, region_name=None
 ):
     kwargs = {}
     if region_name is not None:
         kwargs["region_name"] = region_name
-    client = boto3.client('dynamodb', **kwargs)
+    client = boto3.client("dynamodb", **kwargs)
 
     with patch.object(client, "batch_write_item", return_requestitems_as_unprocessed):
         e_client = EncryptedClient(
@@ -708,10 +688,7 @@ def client_batch_items_unprocessed_check(
         )
 
         batch_write_item_unprocessed_check(
-            encrypted=e_client,
-            initial_item=initial_item,
-            write_transformer=dict_to_ddb,
-            table_name=table_name,
+            encrypted=e_client, initial_item=initial_item, write_transformer=dict_to_ddb, table_name=table_name
         )
 
 

--- a/test/functional/functional_test_utils.py
+++ b/test/functional/functional_test_utils.py
@@ -510,7 +510,7 @@ def batch_write_item_unprocessed_check(
     unprocessed_items = _put_result["UnprocessedItems"]
     assert unprocessed_items != {}
 
-    unprocessed = [operation["PutRequest"]["Item"] for operation in _put_result["UnprocessedItems"][TEST_TABLE_NAME]]
+    unprocessed = [operation["PutRequest"]["Item"] for operation in unprocessed_items[TEST_TABLE_NAME]]
     assert_list_of_items_contains(items, unprocessed, transformer=_nop_transformer)
 
     del items

--- a/test/functional/internal/test_utils.py
+++ b/test/functional/internal/test_utils.py
@@ -62,14 +62,11 @@ def get_test_items(standard_dict_format, table_name="table", with_sort_keys=Fals
 def get_dummy_crypto_config(partition_key_name=None, sort_key_name=None, sign_keys=False):
     context = EncryptionContext(partition_key_name=partition_key_name, sort_key_name=sort_key_name)
     actions = AttributeActions(
-        default_action=CryptoAction.DO_NOTHING,
-        attribute_actions={
-            "encrypt-me": CryptoAction.ENCRYPT_AND_SIGN
-        },
+        default_action=CryptoAction.DO_NOTHING, attribute_actions={"encrypt-me": CryptoAction.ENCRYPT_AND_SIGN}
     )
     if sign_keys:
-        actions.attribute_actions['partition-key'] = CryptoAction.SIGN_ONLY
-        actions.attribute_actions['sort-key'] = CryptoAction.SIGN_ONLY
+        actions.attribute_actions["partition-key"] = CryptoAction.SIGN_ONLY
+        actions.attribute_actions["sort-key"] = CryptoAction.SIGN_ONLY
 
     materials = Mock(spec=CryptographicMaterialsProvider)  # type: CryptographicMaterialsProvider
     return CryptoConfig(materials_provider=materials, encryption_context=context, attribute_actions=actions)
@@ -78,7 +75,7 @@ def get_dummy_crypto_config(partition_key_name=None, sort_key_name=None, sign_ke
 def check_encrypt_batch_write_item_call(request_items, crypto_config):
     def dummy_encrypt(item, **kwargs):
         result = item.copy()
-        result['encrypt-me'] = "pretend Im encrypted"
+        result["encrypt-me"] = "pretend Im encrypted"
         return result
 
     # execute a batch write, but make the write method return ALL the provided items as unprocessed
@@ -96,11 +93,7 @@ def check_encrypt_batch_write_item_call(request_items, crypto_config):
 
 
 @pytest.mark.parametrize(
-    "items",
-    (
-        get_test_items(standard_dict_format=True),
-        get_test_items(standard_dict_format=False),
-    )
+    "items", (get_test_items(standard_dict_format=True), get_test_items(standard_dict_format=False))
 )
 def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_known_partition_key(items):
     crypto_config = get_dummy_crypto_config("partition-key")
@@ -112,7 +105,7 @@ def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_known_part
     (
         get_test_items(standard_dict_format=True, with_sort_keys=True),
         get_test_items(standard_dict_format=False, with_sort_keys=True),
-    )
+    ),
 )
 def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_known_partition_and_sort_keys(items):
     crypto_config = get_dummy_crypto_config("partition-key", "sort-key")
@@ -126,7 +119,7 @@ def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_known_part
         get_test_items(standard_dict_format=False),
         get_test_items(standard_dict_format=True, with_sort_keys=True),
         get_test_items(standard_dict_format=False, with_sort_keys=True),
-    )
+    ),
 )
 def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_unknown_keys(items):
     crypto_config = get_dummy_crypto_config(None, None)
@@ -141,7 +134,7 @@ def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_unknown_ke
         get_test_items(standard_dict_format=False),
         get_test_items(standard_dict_format=True, with_sort_keys=True),
         get_test_items(standard_dict_format=False, with_sort_keys=True),
-    )
+    ),
 )
 def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_unknown_signed_keys(items):
     crypto_config = get_dummy_crypto_config(None, None, sign_keys=True)

--- a/test/functional/internal/test_utils.py
+++ b/test/functional/internal/test_utils.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Test suite for ``dynamodb_encryption_sdk.internal.utils``."""
+import copy
+
+import pytest
+
+from dynamodb_encryption_sdk.encrypted import CryptoConfig
+from dynamodb_encryption_sdk.identifiers import CryptoAction
+from dynamodb_encryption_sdk.internal.utils import encrypt_batch_write_item
+from dynamodb_encryption_sdk.material_providers import CryptographicMaterialsProvider
+from dynamodb_encryption_sdk.structures import AttributeActions, EncryptionContext
+from dynamodb_encryption_sdk.transform import ddb_to_dict
+
+from ..functional_test_vector_generators import attribute_test_vectors
+
+
+def get_test_item(standard_dict_format, partition_key, sort_key):
+    attributes = attribute_test_vectors("serialize")
+
+    attributes = {"attr_" + str(pos): attribute[0] for pos, attribute in enumerate(attributes)}
+    attributes["partition-key"] = {"S": partition_key}
+    if sort_key:
+        attributes["sort-key"] = {"S": sort_key}
+
+    if standard_dict_format:
+        attributes = ddb_to_dict(attributes)
+    return attributes
+
+
+def get_test_items(standard_dict_format, table_name="table"):
+    items = [
+        get_test_item(standard_dict_format, partition_key="key-1", sort_key=None),
+        get_test_item(standard_dict_format, partition_key="key-2", sort_key=None),
+        get_test_item(standard_dict_format, partition_key="key-3", sort_key="sort-1"),
+        get_test_item(standard_dict_format, partition_key="key-4", sort_key="sort-1"),
+        get_test_item(standard_dict_format, partition_key="key-4", sort_key="sort-2"),
+    ]
+
+    for pos, item in enumerate(items):
+        item["encrypt-me"] = table_name + str(pos)
+
+    return {table_name: [{"PutRequest": {"Item": item}} for item in items]}
+
+
+def get_dummy_crypto_config(partition_key_name, sort_key_name, encrypted_attribute_name):
+    context = EncryptionContext(partition_key_name=partition_key_name, sort_key_name=sort_key_name)
+    actions = AttributeActions(
+        default_action=CryptoAction.DO_NOTHING,
+        attribute_actions={encrypted_attribute_name: CryptoAction.ENCRYPT_AND_SIGN},
+    )
+    materials = CryptographicMaterialsProvider()
+    return CryptoConfig(materials_provider=materials, encryption_context=context, attribute_actions=actions)
+
+
+def check_encrypt_batch_write_item_call(request_items, crypto_config, encrypted_attribute_name):
+    def dummy_encrypt(item, **kwargs):
+        result = item.copy()
+        result[encrypted_attribute_name] = "pretend Im encrypted"
+        return result
+
+    result = encrypt_batch_write_item(
+        encrypt_method=dummy_encrypt,
+        write_method=lambda **kwargs: {"UnprocessedItems": kwargs["RequestItems"]},
+        crypto_config_method=lambda **kwargs: crypto_config,
+        RequestItems=copy.deepcopy(request_items),
+    )
+
+    # assert the returned items equal the submitted items
+    unprocessed = result["UnprocessedItems"]
+
+    assert unprocessed == request_items
+
+
+@pytest.mark.parametrize(
+    "items",
+    (
+        (get_test_items(standard_dict_format=True)),
+        (get_test_items(standard_dict_format=False))
+    )
+)
+def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_known_keys(items):
+    crypto_config = get_dummy_crypto_config("partition-key", "sort-key", encrypted_attribute_name="encrypt-me")
+
+    check_encrypt_batch_write_item_call(items, crypto_config, encrypted_attribute_name="encrypt-me")
+
+
+@pytest.mark.parametrize(
+    "items",
+    (
+        (get_test_items(standard_dict_format=True)),
+        (get_test_items(standard_dict_format=False))
+    )
+)
+def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_unknown_keys(items):
+    crypto_config = get_dummy_crypto_config(None, None, encrypted_attribute_name="encrypt-me")
+
+    check_encrypt_batch_write_item_call(items, crypto_config, encrypted_attribute_name="encrypt-me")
+
+
+def test_encrypt_batch_write_returns_plaintext_unprocessed_items_over_multiple_tables():
+    crypto_config = get_dummy_crypto_config("partition-key", "sort-key", encrypted_attribute_name="encrypt-me")
+
+    items = get_test_items(False, "table-one")
+    more_items = get_test_items(False, "table-two")
+    items.update(more_items)
+
+    check_encrypt_batch_write_item_call(items, crypto_config, encrypted_attribute_name="encrypt-me")

--- a/test/functional/internal/test_utils.py
+++ b/test/functional/internal/test_utils.py
@@ -15,38 +15,44 @@
 import copy
 
 import pytest
+from mock import Mock
 
 from dynamodb_encryption_sdk.encrypted import CryptoConfig
 from dynamodb_encryption_sdk.identifiers import CryptoAction
 from dynamodb_encryption_sdk.internal.utils import encrypt_batch_write_item
 from dynamodb_encryption_sdk.material_providers import CryptographicMaterialsProvider
 from dynamodb_encryption_sdk.structures import AttributeActions, EncryptionContext
-from dynamodb_encryption_sdk.transform import ddb_to_dict
+from dynamodb_encryption_sdk.transform import dict_to_ddb
 
-from ..functional_test_vector_generators import attribute_test_vectors
+from ..functional_test_utils import diverse_item
 
 
-def get_test_item(standard_dict_format, partition_key, sort_key):
-    attributes = attribute_test_vectors("serialize")
+def get_test_item(standard_dict_format, partition_key, sort_key=None):
+    attributes = diverse_item()
 
     attributes = {"attr_" + str(pos): attribute[0] for pos, attribute in enumerate(attributes)}
-    attributes["partition-key"] = {"S": partition_key}
-    if sort_key:
-        attributes["sort-key"] = {"S": sort_key}
+    attributes["partition-key"] = partition_key
+    if sort_key is not None:
+        attributes["sort-key"] = sort_key
 
-    if standard_dict_format:
-        attributes = ddb_to_dict(attributes)
+    if not standard_dict_format:
+        attributes = dict_to_ddb(attributes)
     return attributes
 
 
-def get_test_items(standard_dict_format, table_name="table"):
-    items = [
-        get_test_item(standard_dict_format, partition_key="key-1", sort_key=None),
-        get_test_item(standard_dict_format, partition_key="key-2", sort_key=None),
-        get_test_item(standard_dict_format, partition_key="key-3", sort_key="sort-1"),
-        get_test_item(standard_dict_format, partition_key="key-4", sort_key="sort-1"),
-        get_test_item(standard_dict_format, partition_key="key-4", sort_key="sort-2"),
-    ]
+def get_test_items(standard_dict_format, table_name="table", with_sort_keys=False):
+
+    if with_sort_keys:
+        items = [
+            get_test_item(standard_dict_format, partition_key="key-1", sort_key="sort-1"),
+            get_test_item(standard_dict_format, partition_key="key-2", sort_key="sort-1"),
+            get_test_item(standard_dict_format, partition_key="key-2", sort_key="sort-2"),
+        ]
+    else:
+        items = [
+            get_test_item(standard_dict_format, partition_key="key-1"),
+            get_test_item(standard_dict_format, partition_key="key-2"),
+        ]
 
     for pos, item in enumerate(items):
         item["encrypt-me"] = table_name + str(pos)
@@ -54,22 +60,30 @@ def get_test_items(standard_dict_format, table_name="table"):
     return {table_name: [{"PutRequest": {"Item": item}} for item in items]}
 
 
-def get_dummy_crypto_config(partition_key_name, sort_key_name, encrypted_attribute_name):
+def get_dummy_crypto_config(partition_key_name=None, sort_key_name=None, sign_keys=False):
     context = EncryptionContext(partition_key_name=partition_key_name, sort_key_name=sort_key_name)
     actions = AttributeActions(
         default_action=CryptoAction.DO_NOTHING,
-        attribute_actions={encrypted_attribute_name: CryptoAction.ENCRYPT_AND_SIGN},
+        attribute_actions={
+            "encrypt-me": CryptoAction.ENCRYPT_AND_SIGN
+        },
     )
-    materials = CryptographicMaterialsProvider()
+    if sign_keys:
+        actions.attribute_actions['partition-key'] = CryptoAction.SIGN_ONLY
+        if sort_key_name is not None:
+            actions.attribute_actions['sort-key'] = CryptoAction.SIGN_ONLY
+
+    materials = Mock(spec=CryptographicMaterialsProvider)  # type: CryptographicMaterialsProvider
     return CryptoConfig(materials_provider=materials, encryption_context=context, attribute_actions=actions)
 
 
-def check_encrypt_batch_write_item_call(request_items, crypto_config, encrypted_attribute_name):
+def check_encrypt_batch_write_item_call(request_items, crypto_config):
     def dummy_encrypt(item, **kwargs):
         result = item.copy()
-        result[encrypted_attribute_name] = "pretend Im encrypted"
+        result['encrypt-me'] = "pretend Im encrypted"
         return result
 
+    # execute a batch write, but make the write method return ALL the provided items as unprocessed
     result = encrypt_batch_write_item(
         encrypt_method=dummy_encrypt,
         write_method=lambda **kwargs: {"UnprocessedItems": kwargs["RequestItems"]},
@@ -86,34 +100,62 @@ def check_encrypt_batch_write_item_call(request_items, crypto_config, encrypted_
 @pytest.mark.parametrize(
     "items",
     (
-        (get_test_items(standard_dict_format=True)),
-        (get_test_items(standard_dict_format=False))
+        get_test_items(standard_dict_format=True),
+        get_test_items(standard_dict_format=False),
     )
 )
-def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_known_keys(items):
-    crypto_config = get_dummy_crypto_config("partition-key", "sort-key", encrypted_attribute_name="encrypt-me")
-
-    check_encrypt_batch_write_item_call(items, crypto_config, encrypted_attribute_name="encrypt-me")
+def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_known_partition_key(items):
+    crypto_config = get_dummy_crypto_config("partition-key")
+    check_encrypt_batch_write_item_call(items, crypto_config)
 
 
 @pytest.mark.parametrize(
     "items",
     (
-        (get_test_items(standard_dict_format=True)),
-        (get_test_items(standard_dict_format=False))
+        get_test_items(standard_dict_format=True, with_sort_keys=True),
+        get_test_items(standard_dict_format=False, with_sort_keys=True),
+    )
+)
+def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_known_partition_and_sort_keys(items):
+    crypto_config = get_dummy_crypto_config("partition-key", "sort-key")
+    check_encrypt_batch_write_item_call(items, crypto_config)
+
+
+@pytest.mark.parametrize(
+    "items",
+    (
+        get_test_items(standard_dict_format=True),
+        get_test_items(standard_dict_format=False),
+        get_test_items(standard_dict_format=True, with_sort_keys=True),
+        get_test_items(standard_dict_format=False, with_sort_keys=True),
     )
 )
 def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_unknown_keys(items):
-    crypto_config = get_dummy_crypto_config(None, None, encrypted_attribute_name="encrypt-me")
+    crypto_config = get_dummy_crypto_config(None, None)
 
-    check_encrypt_batch_write_item_call(items, crypto_config, encrypted_attribute_name="encrypt-me")
+    check_encrypt_batch_write_item_call(items, crypto_config)
+
+
+@pytest.mark.parametrize(
+    "items",
+    (
+        get_test_items(standard_dict_format=True),
+        get_test_items(standard_dict_format=False),
+        get_test_items(standard_dict_format=True, with_sort_keys=True),
+        get_test_items(standard_dict_format=False, with_sort_keys=True),
+    )
+)
+def test_encrypt_batch_write_returns_plaintext_unprocessed_items_with_unknown_signed_keys(items):
+    crypto_config = get_dummy_crypto_config(None, None, sign_keys=True)
+
+    check_encrypt_batch_write_item_call(items, crypto_config)
 
 
 def test_encrypt_batch_write_returns_plaintext_unprocessed_items_over_multiple_tables():
-    crypto_config = get_dummy_crypto_config("partition-key", "sort-key", encrypted_attribute_name="encrypt-me")
+    crypto_config = get_dummy_crypto_config("partition-key", "sort-key")
 
-    items = get_test_items(False, "table-one")
-    more_items = get_test_items(False, "table-two")
+    items = get_test_items(standard_dict_format=True, table_name="table-one", with_sort_keys=True)
+    more_items = get_test_items(standard_dict_format=False, table_name="table-two", with_sort_keys=True)
     items.update(more_items)
 
-    check_encrypt_batch_write_item_call(items, crypto_config, encrypted_attribute_name="encrypt-me")
+    check_encrypt_batch_write_item_call(items, crypto_config)

--- a/test/functional/internal/test_utils.py
+++ b/test/functional/internal/test_utils.py
@@ -30,7 +30,6 @@ from ..functional_test_utils import diverse_item
 def get_test_item(standard_dict_format, partition_key, sort_key=None):
     attributes = diverse_item()
 
-    attributes = {"attr_" + str(pos): attribute[0] for pos, attribute in enumerate(attributes)}
     attributes["partition-key"] = partition_key
     if sort_key is not None:
         attributes["sort-key"] = sort_key

--- a/test/functional/internal/test_utils.py
+++ b/test/functional/internal/test_utils.py
@@ -69,8 +69,7 @@ def get_dummy_crypto_config(partition_key_name=None, sort_key_name=None, sign_ke
     )
     if sign_keys:
         actions.attribute_actions['partition-key'] = CryptoAction.SIGN_ONLY
-        if sort_key_name is not None:
-            actions.attribute_actions['sort-key'] = CryptoAction.SIGN_ONLY
+        actions.attribute_actions['sort-key'] = CryptoAction.SIGN_ONLY
 
     materials = Mock(spec=CryptographicMaterialsProvider)  # type: CryptographicMaterialsProvider
     return CryptoConfig(materials_provider=materials, encryption_context=context, attribute_actions=actions)


### PR DESCRIPTION
Addresses #92, #91 

Changes the encrypt_batch_write_item utility method to check for UnprocessedItems in the response, and replace them with the original plaintext items.

Couple talking points:
- The encryption process is currently overwriting the plaintext item value, and in order to enable reverting it back I needed to deep copy the RequestItems.
- Handling the possible lack of schema information when searching out the correct plaintext item meant having a fallback that requires all the attributes not marked for encryption to match; a brute-force way of making sure the key attributes match since they aren't encrypted. Not sure if there's a more elegant way.
- I may have put my tests in the wrong place :)
- My tests are low-level implementation tests, should there be a higher-level test that triggers throughput exceeded for e.g. to cover regressions on the higher-level requirement?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
