### PR TITLE
Fix EncryptedPaginator to successfully decrypt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changelog
 Bugfixes
 --------
 * Fix :class:`EncryptedPaginator` to successfully decrypt when using :class:`AwsKmsCryptographicMaterialsProvider`
-  `#105 <https://github.com/aws/aws-dynamodb-encryption-python/pull/118>`_
+  `#118 <https://github.com/aws/aws-dynamodb-encryption-python/pull/118>`_
 
 1.1.0 -- 2019-03-13
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+1.1.1 -- 2019-08-xx
+===================
+
+Bugfixes
+--------
+* Fix :class:`EncryptedPaginator` to successfully decrypt when using :class:`AwsKmsCryptographicMaterialsProvider`
+  `#105 <https://github.com/aws/aws-dynamodb-encryption-python/pull/118>`_
+
 1.1.0 -- 2019-03-13
 ===================
 

--- a/src/dynamodb_encryption_sdk/encrypted/client.py
+++ b/src/dynamodb_encryption_sdk/encrypted/client.py
@@ -22,6 +22,7 @@ from dynamodb_encryption_sdk.internal.utils import (
     crypto_config_from_kwargs,
     decrypt_batch_get_item,
     decrypt_get_item,
+    decrypt_list_of_items,
     decrypt_multi_get,
     encrypt_batch_write_item,
     encrypt_put_item,
@@ -104,8 +105,11 @@ class EncryptedPaginator(object):
         crypto_config, ddb_kwargs = self._crypto_config_method(**kwargs)
 
         for page in self._paginator.paginate(**ddb_kwargs):
-            for pos, value in enumerate(page["Items"]):
-                page["Items"][pos] = self._decrypt_method(item=value, crypto_config=crypto_config)
+            page["Items"] = list(
+                decrypt_list_of_items(
+                    crypto_config=crypto_config, decrypt_method=self._decrypt_method, items=page["Items"]
+                )
+            )
             yield page
 
 

--- a/test/functional/encrypted/test_client.py
+++ b/test/functional/encrypted/test_client.py
@@ -20,7 +20,7 @@ from ..functional_test_utils import (
     build_static_jce_cmp,
     client_batch_items_unprocessed_check,
     client_cycle_batch_items_check,
-    client_cycle_batch_items_check_paginators,
+    client_cycle_batch_items_check_scan_paginator,
     client_cycle_single_item_check,
     set_parametrized_actions,
     set_parametrized_cmp,
@@ -49,8 +49,8 @@ def _client_cycle_batch_items_check(materials_provider, initial_actions, initial
     )
 
 
-def _client_cycle_batch_items_check_paginators(materials_provider, initial_actions, initial_item):
-    return client_cycle_batch_items_check_paginators(
+def _client_cycle_batch_items_check_scan_paginator(materials_provider, initial_actions, initial_item):
+    return client_cycle_batch_items_check_scan_paginator(
         materials_provider, initial_actions, initial_item, TEST_TABLE_NAME, "us-west-2"
     )
 
@@ -73,7 +73,7 @@ def test_ephemeral_batch_item_cycle(example_table, some_cmps, parametrized_actio
 
 def test_ephemeral_batch_item_cycle_paginators(example_table, some_cmps, parametrized_actions, parametrized_item):
     """Test a small number of curated CMPs against a small number of curated items using paginators."""
-    _client_cycle_batch_items_check_paginators(some_cmps, parametrized_actions, parametrized_item)
+    _client_cycle_batch_items_check_scan_paginator(some_cmps, parametrized_actions, parametrized_item)
 
 
 def test_batch_item_unprocessed(example_table, parametrized_actions, parametrized_item):

--- a/test/functional/encrypted/test_client.py
+++ b/test/functional/encrypted/test_client.py
@@ -71,8 +71,8 @@ def test_ephemeral_batch_item_cycle(example_table, some_cmps, parametrized_actio
     _client_cycle_batch_items_check(some_cmps, parametrized_actions, parametrized_item)
 
 
-def test_ephemeral_batch_item_cycle_paginators(example_table, some_cmps, parametrized_actions, parametrized_item):
-    """Test a small number of curated CMPs against a small number of curated items using paginators."""
+def test_ephemeral_batch_item_cycle_scan_paginator(example_table, some_cmps, parametrized_actions, parametrized_item):
+    """Test a small number of curated CMPs against a small number of curated items using the scan paginator."""
     _client_cycle_batch_items_check_scan_paginator(some_cmps, parametrized_actions, parametrized_item)
 
 

--- a/test/functional/encrypted/test_item.py
+++ b/test/functional/encrypted/test_item.py
@@ -38,7 +38,7 @@ pytestmark = [pytest.mark.functional, pytest.mark.local]
 
 def pytest_generate_tests(metafunc):
     set_parametrized_actions(metafunc)
-    set_parametrized_cmp(metafunc)
+    set_parametrized_cmp(metafunc, require_attributes=False)
     set_parametrized_item(metafunc)
 
 

--- a/test/functional/functional_test_utils.py
+++ b/test/functional/functional_test_utils.py
@@ -290,10 +290,7 @@ def _all_possible_cmps(algorithm_generator, require_attributes):
         else:
             outer_cmp = inner_cmp
 
-        yield pytest.param(
-            outer_cmp,
-            id=id_string,
-        )
+        yield pytest.param(outer_cmp, id=id_string)
 
 
 def set_parametrized_cmp(metafunc, require_attributes=True):

--- a/test/integration/encrypted/test_client.py
+++ b/test/integration/encrypted/test_client.py
@@ -14,9 +14,9 @@
 import pytest
 
 from ..integration_test_utils import (  # noqa pylint: disable=unused-import
-    aws_kms_cmp,
     ddb_table_name,
     functional_test_utils,
+    set_parameterized_kms_cmps,
 )
 
 pytestmark = [pytest.mark.integ, pytest.mark.ddb_integ]
@@ -26,6 +26,7 @@ def pytest_generate_tests(metafunc):
     functional_test_utils.set_parametrized_actions(metafunc)
     functional_test_utils.set_parametrized_cmp(metafunc)
     functional_test_utils.set_parametrized_item(metafunc)
+    set_parameterized_kms_cmps(metafunc)
 
 
 def test_ephemeral_item_cycle(ddb_table_name, some_cmps, parametrized_actions, parametrized_item):
@@ -35,10 +36,10 @@ def test_ephemeral_item_cycle(ddb_table_name, some_cmps, parametrized_actions, p
     )
 
 
-def test_ephemeral_item_cycle_kms(ddb_table_name, aws_kms_cmp, parametrized_actions, parametrized_item):
+def test_ephemeral_item_cycle_kms(ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item):
     """Test the AWS KMS CMP against a small number of curated items."""
     functional_test_utils.client_cycle_single_item_check(
-        aws_kms_cmp, parametrized_actions, parametrized_item, ddb_table_name
+        all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name
     )
 
 
@@ -49,10 +50,10 @@ def test_ephemeral_batch_item_cycle(ddb_table_name, some_cmps, parametrized_acti
     )
 
 
-def test_ephemeral_batch_item_cycle_kms(ddb_table_name, aws_kms_cmp, parametrized_actions, parametrized_item):
+def test_ephemeral_batch_item_cycle_kms(ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item):
     """Test the AWS KMS CMP against a small number of curated items."""
     functional_test_utils.client_cycle_batch_items_check(
-        aws_kms_cmp, parametrized_actions, parametrized_item, ddb_table_name
+        all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name
     )
 
 
@@ -64,9 +65,9 @@ def test_ephemeral_batch_item_cycle_scan_paginator(ddb_table_name, some_cmps, pa
 
 
 def test_ephemeral_batch_item_cycle_scan_paginator_kms(
-    ddb_table_name, aws_kms_cmp, parametrized_actions, parametrized_item
+    ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item
 ):
     """Test a the AWS KMS CMP against a small number of curated items using the scan paginator."""
     functional_test_utils.client_cycle_batch_items_check_scan_paginator(
-        aws_kms_cmp, parametrized_actions, parametrized_item, ddb_table_name
+        all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name
     )

--- a/test/integration/encrypted/test_client.py
+++ b/test/integration/encrypted/test_client.py
@@ -63,7 +63,9 @@ def test_ephemeral_batch_item_cycle_scan_paginator(ddb_table_name, some_cmps, pa
     )
 
 
-def test_ephemeral_batch_item_cycle_scan_paginator_kms(ddb_table_name, aws_kms_cmp, parametrized_actions, parametrized_item):
+def test_ephemeral_batch_item_cycle_scan_paginator_kms(
+    ddb_table_name, aws_kms_cmp, parametrized_actions, parametrized_item
+):
     """Test a the AWS KMS CMP against a small number of curated items using the scan paginator."""
     functional_test_utils.client_cycle_batch_items_check_scan_paginator(
         aws_kms_cmp, parametrized_actions, parametrized_item, ddb_table_name

--- a/test/integration/encrypted/test_client.py
+++ b/test/integration/encrypted/test_client.py
@@ -54,3 +54,17 @@ def test_ephemeral_batch_item_cycle_kms(ddb_table_name, aws_kms_cmp, parametrize
     functional_test_utils.client_cycle_batch_items_check(
         aws_kms_cmp, parametrized_actions, parametrized_item, ddb_table_name
     )
+
+
+def test_ephemeral_batch_item_cycle_scan_paginator(ddb_table_name, some_cmps, parametrized_actions, parametrized_item):
+    """Test a small number of curated CMPs against a small number of curated items using the scan paginator."""
+    functional_test_utils.client_cycle_batch_items_check_scan_paginator(
+        some_cmps, parametrized_actions, parametrized_item, ddb_table_name
+    )
+
+
+def test_ephemeral_batch_item_cycle_scan_paginator_kms(ddb_table_name, aws_kms_cmp, parametrized_actions, parametrized_item):
+    """Test a the AWS KMS CMP against a small number of curated items using the scan paginator."""
+    functional_test_utils.client_cycle_batch_items_check_scan_paginator(
+        aws_kms_cmp, parametrized_actions, parametrized_item, ddb_table_name
+    )

--- a/test/integration/encrypted/test_resource.py
+++ b/test/integration/encrypted/test_resource.py
@@ -14,9 +14,9 @@
 import pytest
 
 from ..integration_test_utils import (  # noqa pylint: disable=unused-import
-    aws_kms_cmp,
     ddb_table_name,
     functional_test_utils,
+    set_parameterized_kms_cmps,
 )
 
 pytestmark = [pytest.mark.integ, pytest.mark.ddb_integ]
@@ -26,6 +26,7 @@ def pytest_generate_tests(metafunc):
     functional_test_utils.set_parametrized_actions(metafunc)
     functional_test_utils.set_parametrized_cmp(metafunc)
     functional_test_utils.set_parametrized_item(metafunc)
+    set_parameterized_kms_cmps(metafunc)
 
 
 def test_ephemeral_batch_item_cycle(ddb_table_name, some_cmps, parametrized_actions, parametrized_item):
@@ -35,8 +36,8 @@ def test_ephemeral_batch_item_cycle(ddb_table_name, some_cmps, parametrized_acti
     )
 
 
-def test_ephemeral_batch_item_cycle_kms(ddb_table_name, aws_kms_cmp, parametrized_actions, parametrized_item):
+def test_ephemeral_batch_item_cycle_kms(ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item):
     """Test the AWS KMS CMP against a small number of curated items."""
     functional_test_utils.resource_cycle_batch_items_check(
-        aws_kms_cmp, parametrized_actions, parametrized_item, ddb_table_name
+        all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name
     )

--- a/test/integration/encrypted/test_table.py
+++ b/test/integration/encrypted/test_table.py
@@ -14,9 +14,9 @@
 import pytest
 
 from ..integration_test_utils import (  # noqa pylint: disable=unused-import
-    aws_kms_cmp,
     ddb_table_name,
     functional_test_utils,
+    set_parameterized_kms_cmps,
 )
 
 pytestmark = [pytest.mark.integ, pytest.mark.ddb_integ]
@@ -26,6 +26,7 @@ def pytest_generate_tests(metafunc):
     functional_test_utils.set_parametrized_actions(metafunc)
     functional_test_utils.set_parametrized_cmp(metafunc)
     functional_test_utils.set_parametrized_item(metafunc)
+    set_parameterized_kms_cmps(metafunc)
 
 
 def test_ephemeral_item_cycle(ddb_table_name, some_cmps, parametrized_actions, parametrized_item):
@@ -40,6 +41,6 @@ def test_ephemeral_item_cycle_batch_writer(ddb_table_name, some_cmps, parametriz
     )
 
 
-def test_ephemeral_item_cycle_kms(ddb_table_name, aws_kms_cmp, parametrized_actions, parametrized_item):
+def test_ephemeral_item_cycle_kms(ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item):
     """Test the AWS KMS CMP against a small number of curated items."""
-    functional_test_utils.table_cycle_check(aws_kms_cmp, parametrized_actions, parametrized_item, ddb_table_name)
+    functional_test_utils.table_cycle_check(all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name)

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -48,9 +48,15 @@ def cmk_arn():
     return cmk_arn_value()
 
 
-@pytest.fixture
-def aws_kms_cmp():
-    return AwsKmsCryptographicMaterialsProvider(key_id=cmk_arn_value())
+def set_parameterized_kms_cmps(metafunc, require_attributes=True):
+    inner_cmp = AwsKmsCryptographicMaterialsProvider(key_id=cmk_arn_value())
+    if require_attributes:
+        outer_cmp = functional_test_utils.PassThroughCryptographicMaterialsProviderThatRequiresAttributes(inner_cmp)
+    else:
+        outer_cmp = inner_cmp
+
+    if "all_aws_kms_cmps" in metafunc.fixturenames:
+        metafunc.parametrize("all_aws_kms_cmps", (pytest.param(outer_cmp, id="Standard KMS CMP"),))
 
 
 @pytest.fixture


### PR DESCRIPTION
*Issue #, if available:*
#118 

*Description of changes:*
* Added integration tests that test the scan paginator with KMS crypto materials providers.
* Single-sourced logic for decrypting a list of items, and updated both `EncryptedPaginator` and `decrypt_multi_get` to use it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

