### PR TITLE
Fix upstream tests

### DIFF
--- a/test/integration/encrypted/test_client.py
+++ b/test/integration/encrypted/test_client.py
@@ -36,10 +36,10 @@ def test_ephemeral_item_cycle(ddb_table_name, some_cmps, parametrized_actions, p
     )
 
 
-def test_ephemeral_item_cycle_kms(ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item):
+def test_ephemeral_item_cycle_kms(ddb_table_name, all_aws_kms_cmp_builders, parametrized_actions, parametrized_item):
     """Test the AWS KMS CMP against a small number of curated items."""
     functional_test_utils.client_cycle_single_item_check(
-        all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name
+        all_aws_kms_cmp_builders(), parametrized_actions, parametrized_item, ddb_table_name
     )
 
 
@@ -50,10 +50,12 @@ def test_ephemeral_batch_item_cycle(ddb_table_name, some_cmps, parametrized_acti
     )
 
 
-def test_ephemeral_batch_item_cycle_kms(ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item):
+def test_ephemeral_batch_item_cycle_kms(
+    ddb_table_name, all_aws_kms_cmp_builders, parametrized_actions, parametrized_item
+):
     """Test the AWS KMS CMP against a small number of curated items."""
     functional_test_utils.client_cycle_batch_items_check(
-        all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name
+        all_aws_kms_cmp_builders(), parametrized_actions, parametrized_item, ddb_table_name
     )
 
 
@@ -65,9 +67,9 @@ def test_ephemeral_batch_item_cycle_scan_paginator(ddb_table_name, some_cmps, pa
 
 
 def test_ephemeral_batch_item_cycle_scan_paginator_kms(
-    ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item
+    ddb_table_name, all_aws_kms_cmp_builders, parametrized_actions, parametrized_item
 ):
     """Test a the AWS KMS CMP against a small number of curated items using the scan paginator."""
     functional_test_utils.client_cycle_batch_items_check_scan_paginator(
-        all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name
+        all_aws_kms_cmp_builders(), parametrized_actions, parametrized_item, ddb_table_name
     )

--- a/test/integration/encrypted/test_resource.py
+++ b/test/integration/encrypted/test_resource.py
@@ -36,8 +36,10 @@ def test_ephemeral_batch_item_cycle(ddb_table_name, some_cmps, parametrized_acti
     )
 
 
-def test_ephemeral_batch_item_cycle_kms(ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item):
+def test_ephemeral_batch_item_cycle_kms(
+    ddb_table_name, all_aws_kms_cmp_builders, parametrized_actions, parametrized_item
+):
     """Test the AWS KMS CMP against a small number of curated items."""
     functional_test_utils.resource_cycle_batch_items_check(
-        all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name
+        all_aws_kms_cmp_builders(), parametrized_actions, parametrized_item, ddb_table_name
     )

--- a/test/integration/encrypted/test_table.py
+++ b/test/integration/encrypted/test_table.py
@@ -41,6 +41,8 @@ def test_ephemeral_item_cycle_batch_writer(ddb_table_name, some_cmps, parametriz
     )
 
 
-def test_ephemeral_item_cycle_kms(ddb_table_name, all_aws_kms_cmps, parametrized_actions, parametrized_item):
+def test_ephemeral_item_cycle_kms(ddb_table_name, all_aws_kms_cmp_builders, parametrized_actions, parametrized_item):
     """Test the AWS KMS CMP against a small number of curated items."""
-    functional_test_utils.table_cycle_check(all_aws_kms_cmps, parametrized_actions, parametrized_item, ddb_table_name)
+    functional_test_utils.table_cycle_check(
+        all_aws_kms_cmp_builders(), parametrized_actions, parametrized_item, ddb_table_name
+    )

--- a/test/integration/material_providers/test_aws_kms.py
+++ b/test/integration/material_providers/test_aws_kms.py
@@ -36,10 +36,10 @@ def pytest_generate_tests(metafunc):
     set_parameterized_kms_cmps(metafunc, require_attributes=False)
 
 
-def test_verify_user_agent(all_aws_kms_cmps, caplog):
+def test_verify_user_agent(all_aws_kms_cmp_builders, caplog):
     caplog.set_level(level=logging.DEBUG)
 
-    all_aws_kms_cmps.encryption_materials(EncryptionContext())
+    all_aws_kms_cmp_builders().encryption_materials(EncryptionContext())
 
     assert USER_AGENT_SUFFIX in caplog.text
 
@@ -54,10 +54,10 @@ def _many_items():
 
 
 @pytest.mark.parametrize("item", _many_items())
-def test_aws_kms_diverse_indexes(all_aws_kms_cmps, item):
+def test_aws_kms_diverse_indexes(all_aws_kms_cmp_builders, item):
     """Verify that AWS KMS cycle works for items with all possible combinations for primary index attribute types."""
     crypto_config = CryptoConfig(
-        materials_provider=all_aws_kms_cmps,
+        materials_provider=all_aws_kms_cmp_builders(),
         encryption_context=EncryptionContext(
             partition_key_name="partition_key", sort_key_name="sort_key", attributes=dict_to_ddb(item)
         ),
@@ -68,9 +68,9 @@ def test_aws_kms_diverse_indexes(all_aws_kms_cmps, item):
     functional_test_utils.cycle_item_check(item, crypto_config)
 
 
-def test_aws_kms_item_cycle(all_aws_kms_cmps, parametrized_actions, parametrized_item):
+def test_aws_kms_item_cycle(all_aws_kms_cmp_builders, parametrized_actions, parametrized_item):
     crypto_config = CryptoConfig(
-        materials_provider=all_aws_kms_cmps,
+        materials_provider=all_aws_kms_cmp_builders(),
         encryption_context=EncryptionContext(),
         attribute_actions=parametrized_actions,
     )
@@ -80,9 +80,9 @@ def test_aws_kms_item_cycle(all_aws_kms_cmps, parametrized_actions, parametrized
 @pytest.mark.slow
 @hypothesis_strategies.SLOW_SETTINGS
 @hypothesis.given(item=hypothesis_strategies.ddb_items)
-def test_aws_kms_item_cycle_hypothesis_slow(all_aws_kms_cmps, hypothesis_actions, item):
+def test_aws_kms_item_cycle_hypothesis_slow(all_aws_kms_cmp_builders, hypothesis_actions, item):
     crypto_config = CryptoConfig(
-        materials_provider=all_aws_kms_cmps,
+        materials_provider=all_aws_kms_cmp_builders(),
         encryption_context=EncryptionContext(),
         attribute_actions=hypothesis_actions,
     )
@@ -92,9 +92,9 @@ def test_aws_kms_item_cycle_hypothesis_slow(all_aws_kms_cmps, hypothesis_actions
 @pytest.mark.veryslow
 @hypothesis_strategies.VERY_SLOW_SETTINGS
 @hypothesis.given(item=hypothesis_strategies.ddb_items)
-def test_aws_kms_item_cycle_hypothesis_veryslow(all_aws_kms_cmps, hypothesis_actions, item):
+def test_aws_kms_item_cycle_hypothesis_veryslow(all_aws_kms_cmp_builders, hypothesis_actions, item):
     crypto_config = CryptoConfig(
-        materials_provider=all_aws_kms_cmps,
+        materials_provider=all_aws_kms_cmp_builders(),
         encryption_context=EncryptionContext(),
         attribute_actions=hypothesis_actions,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -119,11 +119,13 @@ commands = {[testenv:freeze-upstream-requirements-base]commands} test/upstream-r
 [testenv:test-upstream-requirements-base]
 sitepackages = False
 recreate = True
+passenv =
 commands = {[testenv:base-command]commands} -m "local and not slow and not veryslow and not nope"
 
 # Test frozen upstream requirements for Python 2.7
 [testenv:test-upstream-requirements-py27]
 basepython = python2.7
+passenv =
 deps = -rtest/upstream-requirements-py27.txt
 sitepackages = {[testenv:test-upstream-requirements-base]sitepackages}
 recreate = {[testenv:test-upstream-requirements-base]recreate}
@@ -132,6 +134,7 @@ commands = {[testenv:test-upstream-requirements-base]commands}
 # Test frozen upstream requirements for Python 3.7
 [testenv:test-upstream-requirements-py37]
 basepython = python3.7
+passenv =
 deps = -rtest/upstream-requirements-py37.txt
 sitepackages = {[testenv:test-upstream-requirements-base]sitepackages}
 recreate = {[testenv:test-upstream-requirements-base]recreate}


### PR DESCRIPTION
*Issue #, if available:* #122 https://github.com/pyca/cryptography/issues/4979

*Description of changes:*

* Fixes upstream test environments to correctly block all environment variables.
* Fixes integration test parameterization logic to fail at execution time rather than test collection time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

