### PR TITLE
Regional clients

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 *********
 
+1.1.2 -- 2019-09-??
+===================
+
+Bugfixes
+--------
+* Fix :class:`AwsKmsCryptographicMaterialsProvider` regional clients override bug
+  `#124 <https://github.com/aws/aws-dynamodb-encryption-python/issues/124>`_
+
 1.1.1 -- 2019-08-29
 ===================
 

--- a/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
+++ b/src/dynamodb_encryption_sdk/material_providers/aws_kms.py
@@ -214,9 +214,6 @@ class AwsKmsCryptographicMaterialsProvider(CryptographicMaterialsProvider):
             default_algorithm=_DEFAULT_SIGNING_ALGORITHM,
             default_key_length=_DEFAULT_SIGNING_KEY_LENGTH,
         )
-        self._regional_clients = (
-            {}
-        )  # type: Dict[Text, botocore.client.BaseClient]  # noqa pylint: disable=attribute-defined-outside-init
 
     def _add_regional_client(self, region_name):
         # type: (Text) -> None

--- a/test/unit/material_providers/test_aws_kms.py
+++ b/test/unit/material_providers/test_aws_kms.py
@@ -231,7 +231,9 @@ def test_loaded_key_infos():
             dict(material_description={"asoiufeoia": "soajfijewi"}),
             dict(
                 regional_clients={
-                    "my-region-1": boto3.session.Session().client("kms", endpoint_url="https://not-a-real-url")
+                    "my-region-1": boto3.session.Session().client(
+                        "kms", region_name="not-a-real-region", endpoint_url="https://not-a-real-url"
+                    )
                 }
             ),
         )

--- a/test/unit/unit_test_utils.py
+++ b/test/unit/unit_test_utils.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Helper utilities for unit tests."""
+import itertools
+
 import pytest
 
 from dynamodb_encryption_sdk.delegated_keys.jce import JceNameLocalDelegatedKey
@@ -25,3 +27,16 @@ def wrapped_cmp():
         signing_key=signing_key, wrapping_key=wrapping_key, unwrapping_key=wrapping_key
     )
     return cmp
+
+
+def all_possible_combinations(*base_values):
+    combinations = [itertools.combinations(base_values, i) for i in range(1, len(base_values) + 1)]
+    return itertools.chain(*combinations)
+
+
+def all_possible_combinations_kwargs(*base_values):
+    for combo in all_possible_combinations(*base_values):
+        kwargs = {}
+        for values in combo:
+            kwargs.update(values)
+        yield kwargs


### PR DESCRIPTION
*Issue #, if available:* #124 

*Description of changes:*
`AwsKmsCryptographicMaterialsProvider` was incorrectly squashing any custom regional clients provided in the constructor.

Also included here are tests to make sure that *no* values provided in the constructor are squashed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

