### PR TITLE
chore: Fix basepython for mypy-py2.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -189,7 +189,7 @@ commands =
     {[testenv:mypy-coverage]commands}
 
 [testenv:mypy-py2]
-basepython = {[testenv:mypy-common]basepython}
+basepython = python2.7
 deps = {[testenv:mypy-common]deps}
 commands =
     python -m mypy \


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* CI is failing for docs because `mypy-py2` requires Python 2, but `basepython` was set to Python 3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

