### PR TITLE
chore: Add AWS CodeBuild buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,15 @@
+version: 0.2
+
+batch:
+  fast-fail: false
+  build-list:
+    - identifier: python2_7
+      buildspec: codebuild/python2.7.yml
+    - identifier: python3_5
+      buildspec: codebuild/python3.5.yml
+    - identifier: python3_6
+      buildspec: codebuild/python3.6.yml
+    - identifier: python3_7
+      buildspec: codebuild/python3.7.yml
+    - identifier: python3_8
+      buildspec: codebuild/python3.8.yml

--- a/codebuild/python2.7.yml
+++ b/codebuild/python2.7.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "py27-integ-slow"
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2: >-
+      arn:aws:kms:eu-central-1:658956600833:key/75414c93-5285-4b57-99c9-30c1cf0a22c2
+
+phases:
+  install:
+    runtime-versions:
+        python: latest
+  build:
+    commands:
+      - pip install tox
+      - tox

--- a/codebuild/python3.5.yml
+++ b/codebuild/python3.5.yml
@@ -14,6 +14,18 @@ phases:
         python: latest
   build:
     commands:
+      # The specific versions are manually installed
+      # because they are not installed
+      # by default in CodeBuild containers.
+      # `pyenv` does not have
+      # a nice way to just install
+      # the latest patch version.
+      # I have selected the current latest patch
+      # rather than try
+      # and manage a one-liner or script.
+      # Testing every minor version
+      # is too extreme at this time.
+      # The choice of versions should be reviewed.
       - pyenv install 3.5.9
       - pyenv local 3.5.9
       - pip install tox tox-pyenv

--- a/codebuild/python3.5.yml
+++ b/codebuild/python3.5.yml
@@ -1,0 +1,20 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "py35-integ-slow"
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2: >-
+      arn:aws:kms:eu-central-1:658956600833:key/75414c93-5285-4b57-99c9-30c1cf0a22c2
+
+phases:
+  install:
+    runtime-versions:
+        python: latest
+  build:
+    commands:
+      - pyenv install 3.5.9
+      - pyenv local 3.5.9
+      - pip install tox tox-pyenv
+      - tox

--- a/codebuild/python3.6.yml
+++ b/codebuild/python3.6.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "py36-integ-slow"
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2: >-
+      arn:aws:kms:eu-central-1:658956600833:key/75414c93-5285-4b57-99c9-30c1cf0a22c2
+
+phases:
+  install:
+    runtime-versions:
+        python: latest
+  build:
+    commands:
+      - pip install tox
+      - tox

--- a/codebuild/python3.7.yml
+++ b/codebuild/python3.7.yml
@@ -1,0 +1,20 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "py37-integ-slow"
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2: >-
+      arn:aws:kms:eu-central-1:658956600833:key/75414c93-5285-4b57-99c9-30c1cf0a22c2
+
+phases:
+  install:
+    runtime-versions:
+        python: latest
+  build:
+    commands:
+      - pyenv install 3.7.9
+      - pyenv local 3.7.9
+      - pip install tox tox-pyenv
+      - tox

--- a/codebuild/python3.7.yml
+++ b/codebuild/python3.7.yml
@@ -14,6 +14,18 @@ phases:
         python: latest
   build:
     commands:
+      # The specific versions are manually installed
+      # because they are not installed
+      # by default in CodeBuild containers.
+      # `pyenv` does not have
+      # a nice way to just install
+      # the latest patch version.
+      # I have selected the current latest patch
+      # rather than try
+      # and manage a one-liner or script.
+      # Testing every minor version
+      # is too extreme at this time.
+      # The choice of versions should be reviewed.
       - pyenv install 3.7.9
       - pyenv local 3.7.9
       - pip install tox tox-pyenv

--- a/codebuild/python3.8.yml
+++ b/codebuild/python3.8.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "py38-integ-slow"
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2: >-
+      arn:aws:kms:eu-central-1:658956600833:key/75414c93-5285-4b57-99c9-30c1cf0a22c2
+
+phases:
+  install:
+    runtime-versions:
+        python: latest
+  build:
+    commands:
+      - pip install tox
+      - tox

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,8 @@ passenv =
     DDB_ENCRYPTION_CLIENT_TEST_TABLE_NAME \
     # Pass through AWS credentials
     AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
+    # AWS Role access in CodeBuild is via the contaner URI
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI \
     # Pass through AWS profile name (useful for local testing)
     AWS_PROFILE \
     # Pass through the default AWS region (used for integration tests)


### PR DESCRIPTION
Adding buildspec to batch build
multiple Python runtimes

* Python 2.7
* Python 3.5
* Python 3.6
* Python 3.7
* Python 3.8

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

