### PR TITLE
chore: Fail build if code coverage is too low

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,3 +13,6 @@ batch:
       buildspec: codebuild/python3.7.yml
     - identifier: python3_8
       buildspec: codebuild/python3.8.yml
+
+    - identifier: code_coverage
+      buildspec: codebuild/coverage/coverage.yml

--- a/codebuild/coverage/coverage.yml
+++ b/codebuild/coverage/coverage.yml
@@ -1,0 +1,14 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "coverage"
+
+phases:
+  install:
+    runtime-versions:
+      python: latest
+  build:
+    commands:
+      - pip install tox
+      - tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ branch = True
 
 [coverage:report]
 show_missing = True
+fail_under = 90
 
 [mypy]
 ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,12 @@ envlist =
 # test-release :: Builds dist files and uploads to testpypi pypirc profile.
 # release :: Builds dist files and uploads to pypi pypirc profile.
 
+# Reporting environments:
+#
+# coverage :: Runs code coverage, failing the build if coverage is below the configured threshold
+
 [testenv:base-command]
-commands = pytest --basetemp={envtmpdir} -l --cov dynamodb_encryption_sdk {posargs}
+commands = pytest --basetemp={envtmpdir} -l {posargs}
 
 [testenv]
 passenv =
@@ -85,6 +89,10 @@ commands =
     manual: {[testenv:base-command]commands}
     # Only run examples tests
     examples: {[testenv:base-command]commands} examples/test/ -m "examples"
+
+# Run code coverage on the unit tests
+[testenv:coverage]
+commands = {[testenv:base-command]commands} --cov dynamodb_encryption_sdk test/ -m "local and not slow and not veryslow and not nope"
 
 # Verify that local tests work without environment variables present
 [testenv:nocmk]


### PR DESCRIPTION
*Description of changes:*
Remove code coverage from base python command, add a dedicated code coverage environment, as well as code build specs to run it.

See also: https://github.com/aws/aws-encryption-sdk-python/pull/325

Threshold of 90% chosen because current coverage is 91%.

*Testing:*
Building gives me:
```
Required test coverage of 90.0% reached. Total coverage: 91.05%
```
If I bump the threshold to 95, the build fails with:
```
FAIL Required test coverage of 95.0% not reached. Total coverage: 91.05%
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

