### PR TITLE
Manually updating rsa version in upstream requirements

### DIFF
--- a/test/README.rst
+++ b/test/README.rst
@@ -31,6 +31,5 @@ and `upstream-requirements-py27.txt`, run these commands:
 Test them using:
 
    .. code::
-
       $ tox -e test-upstream-requirements-py27
       $ tox -e test-upstream-requirements-py37

--- a/test/README.rst
+++ b/test/README.rst
@@ -31,5 +31,6 @@ and `upstream-requirements-py27.txt`, run these commands:
 Test them using:
 
    .. code::
+
       $ tox -e test-upstream-requirements-py27
       $ tox -e test-upstream-requirements-py37

--- a/test/upstream-requirements-py27.txt
+++ b/test/upstream-requirements-py27.txt
@@ -63,7 +63,7 @@ pytz==2019.3
 PyYAML==5.1.2
 requests==2.22.0
 responses==0.10.6
-rsa==4.0
+rsa==4.5
 s3transfer==0.2.1
 scandir==1.10.0
 six==1.12.0

--- a/test/upstream-requirements-py37.txt
+++ b/test/upstream-requirements-py37.txt
@@ -51,7 +51,7 @@ pytz==2019.3
 PyYAML==5.1.2
 requests==2.22.0
 responses==0.10.6
-rsa==4.0
+rsa==4.5
 s3transfer==0.2.1
 six==1.12.0
 sshpubkeys==3.1.0


### PR DESCRIPTION
Dependabot's attempt failed because 4.1 is in a bad state on pypi: https://github.com/aws/aws-dynamodb-encryption-python/pull/154

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

