### PR TITLE
Add explicit support for py38 and py39

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -69,6 +69,7 @@ jobs:
           - 3.6
           - 3.7
           - 3.8
+          - 3.9
           - 3.x
         category:
           - local-slow

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,8 @@ batch:
       buildspec: codebuild/python3.7.yml
     - identifier: python3_8
       buildspec: codebuild/python3.8.yml
+    - identifier: python3_9
+      buildspec: codebuild/python3.9.yml
 
     - identifier: code_coverage
       buildspec: codebuild/coverage/coverage.yml

--- a/codebuild/python3.9.yml
+++ b/codebuild/python3.9.yml
@@ -1,0 +1,20 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "py39-integ-slow"
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2: >-
+      arn:aws:kms:eu-central-1:658956600833:key/75414c93-5285-4b57-99c9-30c1cf0a22c2
+
+phases:
+  install:
+    runtime-versions:
+        python: latest
+  build:
+    commands:
+      - pyenv install 3.9.0
+      - pyenv local 3.9.0
+      - pip install tox tox-pyenv
+      - tox

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Security",
         "Topic :: Security :: Cryptography",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,35,36,37,38}-{local,integ,ddb,examples}-fast,
+    py{27,35,36,37,38,39}-{local,integ,ddb,examples}-fast,
     nocmk, sourcebuildcheck,
     docs, bandit, doc8, readme,
     flake8{,-tests,-examples}, pylint{,-tests,-examples},


### PR DESCRIPTION
*Description of changes:*
We already had some 3.8 testing, this adds 3.9 and adds both to our list of supported versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


