### PR TITLE
chore: Fix static analysis

### DIFF
--- a/src/dynamodb_encryption_sdk/material_providers/most_recent.py
+++ b/src/dynamodb_encryption_sdk/material_providers/most_recent.py
@@ -282,7 +282,7 @@ class CachingMostRecentProvider(CryptographicMaterialsProvider):
         :raises AttributeError: if provider could not locate version
         """
         blocking_wait = bool(ttl_action is TtlActions.EXPIRED)
-        acquired = self._lock.acquire(blocking_wait)
+        acquired = self._lock.acquire(blocking_wait)  # pylint: disable=consider-using-with
         if not acquired:
             # We failed to acquire the lock.
             # If blocking, we will never reach this point.
@@ -320,7 +320,7 @@ class CachingMostRecentProvider(CryptographicMaterialsProvider):
         :rtype: CryptographicMaterialsProvider
         """
         blocking_wait = bool(ttl_action is TtlActions.EXPIRED)
-        acquired = self._lock.acquire(blocking_wait)
+        acquired = self._lock.acquire(blocking_wait)  # pylint: disable=consider-using-with
 
         if not acquired:
             # We failed to acquire the lock.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Disabling pylint "consider-using-with" on those two lines to make the static analysis happy again. The locking logic in those sections is deliberate, and refactoring to using 'with' is not worth the risk of updating any of this logic.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

