### PR TITLE
feat: Py310 & Runtime Python Verison Check

### DIFF
--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -32,7 +32,7 @@ jobs:
           - black-check
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - run: |

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -39,7 +39,7 @@ jobs:
 #          - examples
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.platform.architecture }}

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Getting Started
 Required Prerequisites
 ======================
 
-* Python 3.5+
+* Python 3.6+
 
 
 Installation

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,8 @@ batch:
       buildspec: codebuild/python3.8.yml
     - identifier: python3_9
       buildspec: codebuild/python3.9.yml
+    - identifier: python3_10
+      buildspec: codebuild/python3.10.yml
 
     - identifier: code_coverage
       buildspec: codebuild/coverage/coverage.yml

--- a/codebuild/python3.10.yml
+++ b/codebuild/python3.10.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    TOXENV: "py10-integ-slow"
+    TOXENV: "py310-integ-slow"
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
       arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2: >-

--- a/codebuild/python3.10.yml
+++ b/codebuild/python3.10.yml
@@ -1,0 +1,20 @@
+version: 0.2
+
+env:
+  variables:
+    TOXENV: "py10-integ-slow"
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID: >-
+      arn:aws:kms:us-west-2:658956600833:key/b3537ef1-d8dc-4780-9f5a-55776cbb2f7f
+    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID_2: >-
+      arn:aws:kms:eu-central-1:658956600833:key/75414c93-5285-4b57-99c9-30c1cf0a22c2
+
+phases:
+  install:
+    runtime-versions:
+      python: latest
+  build:
+    commands:
+      - pyenv install 3.10.0
+      - pyenv local 3.10.0
+      - pip install tox tox-pyenv
+      - tox

--- a/codebuild/python3.5.yml
+++ b/codebuild/python3.5.yml
@@ -26,7 +26,7 @@ phases:
       # Testing every minor version
       # is too extreme at this time.
       # The choice of versions should be reviewed.
-      - pyenv install 3.5.9
-      - pyenv local 3.5.9
+      - pyenv install 3.5.10
+      - pyenv local 3.5.10
       - pip install tox tox-pyenv
       - tox

--- a/codebuild/python3.6.yml
+++ b/codebuild/python3.6.yml
@@ -14,5 +14,7 @@ phases:
         python: latest
   build:
     commands:
-      - pip install tox
+      - pyenv install 3.6.15
+      - pyenv local 3.6.15
+      - pip install tox tox-pyenv
       - tox

--- a/codebuild/python3.7.yml
+++ b/codebuild/python3.7.yml
@@ -26,7 +26,7 @@ phases:
       # Testing every minor version
       # is too extreme at this time.
       # The choice of versions should be reviewed.
-      - pyenv install 3.7.9
-      - pyenv local 3.7.9
+      - pyenv install 3.7.12
+      - pyenv local 3.7.12
       - pip install tox tox-pyenv
       - tox

--- a/codebuild/python3.8.yml
+++ b/codebuild/python3.8.yml
@@ -14,7 +14,7 @@ phases:
         python: latest
   build:
     commands:
-      - pyenv install 3.8.6
-      - pyenv local 3.8.6
+      - pyenv install 3.8.12
+      - pyenv local 3.8.12
       - pip install tox tox-pyenv
       - tox

--- a/codebuild/python3.9.yml
+++ b/codebuild/python3.9.yml
@@ -14,7 +14,7 @@ phases:
         python: latest
   build:
     commands:
-      - pyenv install 3.9.0
-      - pyenv local 3.9.0
+      - pyenv install 3.9.7
+      - pyenv local 3.9.7
       - pip install tox tox-pyenv
       - tox

--- a/examples/test/examples_test_utils.py
+++ b/examples/test/examples_test_utils.py
@@ -1,13 +1,25 @@
-"""Helper utilities for use while testing examples."""
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Helper utilities for use while testing examples.
+
+isort:skip_file
+"""
 import os
 import sys
 
 os.environ["AWS_ENCRYPTION_SDK_EXAMPLES_TESTING"] = "yes"
 sys.path.extend([os.sep.join([os.path.dirname(__file__), "..", "..", "test", "integration"])])
 
-from integration_test_utils import (
-    cmk_arn,
-    cmk_mrk_arn,
-    ddb_table_name,
-    second_cmk_mrk_arn,
-)  # noqa pylint: disable=unused-import
+# fmt: off
+from integration_test_utils import cmk_arn, cmk_mrk_arn, ddb_table_name, second_cmk_mrk_arn  # noqa pylint: disable=unused-import
+# fmt: on

--- a/examples/test/examples_test_utils.py
+++ b/examples/test/examples_test_utils.py
@@ -5,4 +5,9 @@ import sys
 os.environ["AWS_ENCRYPTION_SDK_EXAMPLES_TESTING"] = "yes"
 sys.path.extend([os.sep.join([os.path.dirname(__file__), "..", "..", "test", "integration"])])
 
-from integration_test_utils import cmk_arn, cmk_mrk_arn, ddb_table_name, second_cmk_mrk_arn  # noqa pylint: disable=unused-import
+from integration_test_utils import (
+    cmk_arn,
+    cmk_mrk_arn,
+    ddb_table_name,
+    second_cmk_mrk_arn,
+)  # noqa pylint: disable=unused-import

--- a/examples/test/test_aws_kms_encrypted_examples.py
+++ b/examples/test/test_aws_kms_encrypted_examples.py
@@ -20,7 +20,12 @@ from dynamodb_encryption_sdk_examples import (
     aws_kms_multi_region_key,
 )
 
-from .examples_test_utils import cmk_arn, cmk_mrk_arn, ddb_table_name, second_cmk_mrk_arn  # noqa pylint: disable=unused-import
+from .examples_test_utils import (  # noqa pylint: disable=unused-import
+    cmk_arn,
+    cmk_mrk_arn,
+    ddb_table_name,
+    second_cmk_mrk_arn,
+)
 
 pytestmark = [pytest.mark.examples]
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/src/dynamodb_encryption_sdk/__init__.py
+++ b/src/dynamodb_encryption_sdk/__init__.py
@@ -20,7 +20,9 @@ from dynamodb_encryption_sdk.encrypted.item import (
 )
 from dynamodb_encryption_sdk.encrypted.resource import EncryptedResource
 from dynamodb_encryption_sdk.encrypted.table import EncryptedTable
-from dynamodb_encryption_sdk.identifiers import __version__
+from dynamodb_encryption_sdk.identifiers import __version__, check_python_version
+
+check_python_version()
 
 __all__ = (
     "decrypt_dynamodb_item",
@@ -30,5 +32,6 @@ __all__ = (
     "EncryptedClient",
     "EncryptedResource",
     "EncryptedTable",
+    "check_python_version",
     "__version__",
 )

--- a/src/dynamodb_encryption_sdk/identifiers.py
+++ b/src/dynamodb_encryption_sdk/identifiers.py
@@ -77,7 +77,7 @@ class PythonVersionSupport:
     WARN_BELOW_MAJOR = 3
     WARN_BELOW_MINOR = 6
     ERROR_BELOW_MAJOR = 3
-    ERROR_BELOW_MINOR = 5
+    ERROR_BELOW_MINOR = 6
     ERROR_DATE = datetime.datetime(year=2022, month=1, day=1)
 
 

--- a/src/dynamodb_encryption_sdk/identifiers.py
+++ b/src/dynamodb_encryption_sdk/identifiers.py
@@ -11,9 +11,20 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Unique identifiers used by the DynamoDB Encryption Client."""
+import datetime
+import sys
+import warnings
 from enum import Enum
 
-__all__ = ("LOGGER_NAME", "CryptoAction", "EncryptionKeyType", "KeyEncodingType")
+__all__ = (
+    "LOGGER_NAME",
+    "CryptoAction",
+    "EncryptionKeyType",
+    "KeyEncodingType",
+    "PythonVersionSupport",
+    "check_python_version",
+)
+
 __version__ = "3.0.0"
 
 LOGGER_NAME = "dynamodb_encryption_sdk"
@@ -57,3 +68,45 @@ class KeyEncodingType(Enum):
     RAW = 0
     DER = 1
     PEM = 2
+
+
+# pylint: disable=too-few-public-methods
+class PythonVersionSupport:
+    """Configures Python Version warnings/error messaging"""
+
+    WARN_BELOW_MAJOR = 3
+    WARN_BELOW_MINOR = 6
+    ERROR_BELOW_MAJOR = 3
+    ERROR_BELOW_MINOR = 5
+    ERROR_DATE = datetime.datetime(year=2022, month=1, day=1)
+
+
+def check_python_version(
+    warn_below_major=PythonVersionSupport.WARN_BELOW_MAJOR,
+    warn_below_minor=PythonVersionSupport.WARN_BELOW_MINOR,
+    error_below_major=PythonVersionSupport.ERROR_BELOW_MAJOR,
+    error_below_minor=PythonVersionSupport.ERROR_BELOW_MINOR,
+    error_date=PythonVersionSupport.ERROR_DATE,
+):
+    """Checks that we are on a supported version of Python.
+    Prints an error message to stderr if the Python Version is unsupported and therefore untested.
+    Emits a warning if the Python version will be unsupported.
+    """
+    if datetime.datetime.now() > error_date and (
+        sys.version_info.major < error_below_major or sys.version_info.minor < error_below_minor
+    ):
+        sys.stderr.write(
+            "ERROR: Python {} is not supported by the aws-encryption-sdk! ".format(
+                ".".join(map(str, [sys.version_info.major, sys.version_info.minor]))
+            )
+            + "Please upgrade to Python {} or higher.".format(".".join(map(str, [warn_below_major, warn_below_minor])))
+        )
+        return
+    if sys.version_info.major < warn_below_major or sys.version_info.minor < warn_below_minor:
+        warnings.warn(
+            "Python {} support will be removed in a future release. ".format(
+                ".".join(map(str, [sys.version_info.major, sys.version_info.minor]))
+            )
+            + "Please upgrade to Python {} or higher.".format(".".join(map(str, [warn_below_major, warn_below_minor]))),
+            DeprecationWarning,
+        )

--- a/src/dynamodb_encryption_sdk/material_providers/most_recent.py
+++ b/src/dynamodb_encryption_sdk/material_providers/most_recent.py
@@ -35,9 +35,7 @@ except ImportError:  # pragma: no cover
     pass
 
 
-__all__ = (
-    "CachingMostRecentProvider",
-)
+__all__ = ("CachingMostRecentProvider",)
 _LOGGER = logging.getLogger(LOGGER_NAME)
 #: Grace period during which we will return the latest local materials. This allows multiple
 #: threads to be using this same provider without risking lock contention or many threads

--- a/test/unit/test_check_python_version.py
+++ b/test/unit/test_check_python_version.py
@@ -1,0 +1,63 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+# pylint: disable=no-self-use
+"""Unit test suite for ensuring the Python Runtime is supported."""
+import datetime
+import sys
+
+import mock
+import pytest
+
+from dynamodb_encryption_sdk import check_python_version
+from dynamodb_encryption_sdk.identifiers import PythonVersionSupport
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
+
+class TestBeforeErrorDate:
+    def test_happy_version(self):
+        with mock.patch.object(sys, "version_info") as v_info:
+            v_info.major = PythonVersionSupport.WARN_BELOW_MAJOR
+            v_info.minor = PythonVersionSupport.WARN_BELOW_MINOR
+            with pytest.warns(None) as record:
+                check_python_version(error_date=datetime.datetime.now() + datetime.timedelta(days=1))
+            assert len(record) == 0
+
+    def test_below_warn(self):
+        with mock.patch.object(sys, "version_info") as v_info:
+            v_info.major = PythonVersionSupport.WARN_BELOW_MAJOR - 1
+            v_info.minor = PythonVersionSupport.WARN_BELOW_MINOR
+            with pytest.warns(DeprecationWarning):
+                check_python_version(error_date=datetime.datetime.now() + datetime.timedelta(days=1))
+
+
+class TestAfterErrorDate:
+    def test_happy_version(self, capsys):
+        with mock.patch.object(sys, "version_info") as v_info:
+            v_info.major = PythonVersionSupport.WARN_BELOW_MAJOR
+            v_info.minor = PythonVersionSupport.WARN_BELOW_MINOR
+            with pytest.warns(None) as record:
+                check_python_version(error_date=datetime.datetime.now() - datetime.timedelta(days=1))
+            assert len(record) == 0
+            captured = capsys.readouterr().err
+            assert "ERROR" not in captured
+
+    def test_below_error(self, capsys):
+        with mock.patch.object(sys, "version_info") as v_info:
+            v_info.major = PythonVersionSupport.ERROR_BELOW_MAJOR
+            v_info.minor = PythonVersionSupport.ERROR_BELOW_MINOR - 1
+            with pytest.warns(None) as record:
+                check_python_version(error_date=datetime.datetime.now() - datetime.timedelta(days=1))
+            assert len(record) == 0
+            captured = capsys.readouterr().err
+            assert "ERROR" in captured

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38,39}-{local,integ,ddb,examples}-fast,
+    py{35,36,37,38,39,310}-{local,integ,ddb,examples}-fast,
     nocmk, sourcebuildcheck,
     docs, bandit, doc8, readme,
     flake8{,-tests,-examples}, pylint{,-tests,-examples},


### PR DESCRIPTION
*Issue #, if available:* No Issue

*Description of changes:*

This PR:
- Fixes the failing static analysis checks by suppressing f-string lint requirements
- Updates the Minor Python Versions used by CodeBuild to the latest available
- Fixes the GitHub CI Workflows by updating the Python Setup used
- Implements testing against Python 3.10.0 on CodeBuild
- Implements a runtime check against the Python Runtime using the library.

The Runtime Check runs when `__init__.py` is loaded. 
The Runtime Check:
- Issues a WARNING if the Python Version will become unsupported.
- Prints an ERROR to STDERR if Python Version is unsupported.
- Will start issuing WARNING for Python Version less than 3.6.
- Will start printing ERROR for Python Version less than 3.6 AFTER Jan 1st, 2022.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

