### PR TITLE
chore: Fix readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+   configuration: doc/conf.py
+
+# Don't need to build documentation for test vectors or any other
+# sub modules
+submodules:
+  exclude: all
+
+python:
+  version: 3.8
+  install:
+    - requirements: doc/requirements.txt
+    - method: setuptools
+      path: .

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>=1.3.0
-sphinx_rtd_theme
+sphinx==4.2.0
+sphinx_rtd_theme==1.0.0


### PR DESCRIPTION
*Description of changes:*
Same fixes as here: https://github.com/aws/aws-encryption-sdk-python/commit/193dfc70c44b80e28c9f5abe2000db6084f83ccf

Except this repo didn't yet have a dedicated readthedocs config, so I've added it.

See failing build here: https://readthedocs.org/projects/aws-dynamodb-encryption-python/builds/15239121/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
