### PR TITLE
chore: Fix release validation

### DIFF
--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -15,7 +15,9 @@ env:
 phases:
   install:
     commands:
-      - pip install tox
+      - pyenv install 3.8.12
+      - pyenv local 3.8.12
+      - pip install tox tox-pyenv
     runtime-versions:
       python: latest
   pre_build:

--- a/codebuild/release/validate.yml
+++ b/codebuild/release/validate.yml
@@ -15,9 +15,7 @@ env:
 phases:
   install:
     commands:
-      - pyenv install 3.8.12
-      - pyenv local 3.8.12
-      - pip install tox tox-pyenv
+      - pip install tox
     runtime-versions:
       python: latest
   pre_build:
@@ -30,7 +28,7 @@ phases:
       - |
         while [ $NUM_RETRIES -gt 0 ]
         do
-          tox -re py38-examples
+          tox -re py3-examples
           if [ $? -eq 0 ]; then
             break
           fi

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,7 +62,7 @@ exclude_trees = ["_build"]
 pygments_style = "sphinx"
 
 autoclass_content = "both"
-autodoc_default_flags = ["show-inheritance", "members"]
+autodoc_default_options = { "members": True, "show-inheritance": True }
 autodoc_member_order = "bysource"
 
 html_theme = "sphinx_rtd_theme"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,7 +62,7 @@ exclude_trees = ["_build"]
 pygments_style = "sphinx"
 
 autoclass_content = "both"
-autodoc_default_options = { "members": True, "show-inheritance": True }
+autodoc_default_options = {"members": True, "show-inheritance": True}
 autodoc_member_order = "bysource"
 
 html_theme = "sphinx_rtd_theme"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==2.4.0
+sphinx==4.2.0
 sphinx_rtd_theme==1.0.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==4.2.0
+sphinx==2.4.0
 sphinx_rtd_theme==1.0.0

--- a/examples/tox.ini
+++ b/examples/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 envlist =
-    py{36,37,38,39}-examples
+    py{3,36,37,38,39}-examples
 
 [testenv:base-command]
 commands = python -m pytest --basetemp={envtmpdir} -l {posargs}


### PR DESCRIPTION
*Description of changes:*
Fixes discovered during the most recent release.

Also fix the doc generation. When we pulled in the newest version of sphinx it changed how the configuration works, specifically the `autodoc_default_flags` parameter we were using is now deprecated. See [docs](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_default_flags)

To see the effect, compare the good [stable docs](https://aws-dynamodb-encryption-python.readthedocs.io/en/stable/lib/materials_providers/aws_kms.html) to the empty [latest docs](https://aws-dynamodb-encryption-python.readthedocs.io/en/latest/lib/materials_providers/aws_kms.html)

*Testing:*
CI is failing the broken link check on the docs because it always hits the public docs (which don't yet incorporate this fix). I've confirmed locally (`tox -e serve-docs`) that we're back to generating the full docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


