### PR TITLE
chore(deps): bump black from 22.1.0 to 22.3.0

### DIFF
--- a/dev_requirements/linter-requirements.txt
+++ b/dev_requirements/linter-requirements.txt
@@ -1,5 +1,5 @@
 bandit==1.7.2
-black==22.1.0
+black==22.3.0
 doc8==0.10.1
 flake8==4.0.1
 flake8-docstrings==1.6.0


### PR DESCRIPTION
*Description of changes:*
Update Black to 22.3.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

