### PR TITLE
chore: bump ci deps

### DIFF
--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -32,7 +32,7 @@ jobs:
           - black-check
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - run: |

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -39,7 +39,7 @@ jobs:
 #          - examples
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.platform.architecture }}
@@ -61,7 +61,7 @@ jobs:
           - test-upstream-requirements-py37
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - run: |
@@ -82,7 +82,7 @@ jobs:
           - test-upstream-requirements-py311
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
       - run: |

--- a/test/upstream-requirements-py311.txt
+++ b/test/upstream-requirements-py311.txt
@@ -4,7 +4,7 @@ botocore==1.23.51
 certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==3.0.1
-coverage==7.0.5
+coverage==7.1.0
 cryptography==39.0.1
 execnet==1.9.0
 hypothesis==6.31.6
@@ -19,9 +19,9 @@ packaging==23.0
 pluggy==1.0.0
 py==1.11.0
 pycparser==2.21
-pytest==7.0.0
+pytest==7.2.1
 pytest-cov==3.0.0
-pytest-forked==1.4.0
+pytest-forked==1.6.0
 pytest-mock==3.10.0
 pytest-xdist==2.5.0
 python-dateutil==2.8.2
@@ -32,8 +32,7 @@ s3transfer==0.5.2
 six==1.16.0
 sortedcontainers==2.4.0
 toml==0.10.2
-tomli==2.0.1
-types-toml==0.10.8.1
+types-toml==0.10.8.5
 urllib3==1.26.14
-Werkzeug==2.2.2
+Werkzeug==2.2.3
 xmltodict==0.13.0

--- a/test/upstream-requirements-py37.txt
+++ b/test/upstream-requirements-py37.txt
@@ -4,8 +4,9 @@ botocore==1.23.51
 certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==3.0.1
-coverage==7.0.5
+coverage==7.1.0
 cryptography==39.0.1
+exceptiongroup==1.1.0
 execnet==1.9.0
 hypothesis==6.31.6
 idna==3.4
@@ -20,9 +21,9 @@ packaging==23.0
 pluggy==1.0.0
 py==1.11.0
 pycparser==2.21
-pytest==7.0.0
+pytest==7.2.1
 pytest-cov==3.0.0
-pytest-forked==1.4.0
+pytest-forked==1.6.0
 pytest-mock==3.10.0
 pytest-xdist==2.5.0
 python-dateutil==2.8.2
@@ -34,9 +35,9 @@ six==1.16.0
 sortedcontainers==2.4.0
 toml==0.10.2
 tomli==2.0.1
-types-toml==0.10.8.1
-typing_extensions==4.4.0
+types-toml==0.10.8.5
+typing_extensions==4.5.0
 urllib3==1.26.14
-Werkzeug==2.2.2
+Werkzeug==2.2.3
 xmltodict==0.13.0
-zipp==3.11.0
+zipp==3.14.0


### PR DESCRIPTION
*Issue #, if available:* Update frozen upstream dependencies & GitHub's setup-python

*Description of changes:*
- https://github.com/aws/aws-dynamodb-encryption-python/pull/309
- https://github.com/aws/aws-dynamodb-encryption-python/pull/556

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

