### PR TITLE
fix parallel test support and enable in CI

### DIFF
--- a/dev_requirements/test-requirements.txt
+++ b/dev_requirements/test-requirements.txt
@@ -4,6 +4,6 @@ moto==3.0.2
 pytest==7.2.1
 pytest-cov==3.0.0
 pytest-mock==3.10.0
-pytest-xdist==2.5.0
+pytest-xdist==3.2.0
 boto3==1.20.51
 botocore==1.23.51

--- a/test/unit/material_providers/test_aws_kms.py
+++ b/test/unit/material_providers/test_aws_kms.py
@@ -220,36 +220,32 @@ def test_loaded_key_infos():
     assert cmp._regional_clients == {}
 
 
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        pytest.param(val, id=str(val))
-        for val in all_possible_combinations_kwargs(
-            {},
-            dict(botocore_session=botocore.session.Session()),
-            dict(grant_tokens=("sdvoaweih", "auwshefiouawh")),
-            dict(material_description={"asoiufeoia": "soajfijewi"}),
-            dict(
-                regional_clients={
-                    "my-region-1": boto3.session.Session().client(
-                        "kms", region_name="not-a-real-region", endpoint_url="https://not-a-real-url"
-                    )
-                }
-            ),
-        )
-    ],
-)
-def test_kms_cmp_values_set(kwargs):
-    cmp = AwsKmsCryptographicMaterialsProvider(key_id="example_key_id", **kwargs)
+def test_kms_cmp_values_set():
+    # These aren't parametrized to avoid issues with pytest-xdist test mismatches
+    # due to different session objects per process
+    for kwargs in all_possible_combinations_kwargs(
+        {},
+        dict(botocore_session=botocore.session.Session()),
+        dict(grant_tokens=("sdvoaweih", "auwshefiouawh")),
+        dict(material_description={"asoiufeoia": "soajfijewi"}),
+        dict(
+            regional_clients={
+                "my-region-1": boto3.session.Session().client(
+                    "kms", region_name="not-a-real-region", endpoint_url="https://not-a-real-url"
+                )
+            }
+        ),
+    ):
+        cmp = AwsKmsCryptographicMaterialsProvider(key_id="example_key_id", **kwargs)
 
-    assert cmp._key_id == "example_key_id"
+        assert cmp._key_id == "example_key_id"
 
-    if "botocore_session" in kwargs:
-        assert cmp._botocore_session == kwargs["botocore_session"]
+        if "botocore_session" in kwargs:
+            assert cmp._botocore_session == kwargs["botocore_session"]
 
-    assert cmp._grant_tokens == kwargs.get("grant_tokens", ())
-    assert cmp._material_description == kwargs.get("material_description", {})
-    assert cmp._regional_clients == kwargs.get("regional_clients", {})
+        assert cmp._grant_tokens == kwargs.get("grant_tokens", ())
+        assert cmp._material_description == kwargs.get("material_description", {})
+        assert cmp._regional_clients == kwargs.get("regional_clients", {})
 
 
 def test_add_regional_client_known_region(default_kms_cmp, patch_boto3_session):

--- a/test/upstream-requirements-py311.txt
+++ b/test/upstream-requirements-py311.txt
@@ -23,7 +23,7 @@ pytest==7.2.1
 pytest-cov==3.0.0
 pytest-forked==1.6.0
 pytest-mock==3.10.0
-pytest-xdist==2.5.0
+pytest-xdist==3.2.0
 python-dateutil==2.8.2
 pytz==2022.7.1
 requests==2.28.2

--- a/test/upstream-requirements-py37.txt
+++ b/test/upstream-requirements-py37.txt
@@ -25,7 +25,7 @@ pytest==7.2.1
 pytest-cov==3.0.0
 pytest-forked==1.6.0
 pytest-mock==3.10.0
-pytest-xdist==2.5.0
+pytest-xdist==3.2.0
 python-dateutil==2.8.2
 pytz==2022.7.1
 requests==2.28.2

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ envlist =
 # coverage :: Runs code coverage, failing the build if coverage is below the configured threshold
 
 [testenv:base-command]
-commands = pytest --basetemp={envtmpdir} -l {posargs}
+commands = pytest -n auto --basetemp={envtmpdir} -l {posargs}
 
 [testenv]
 passenv =
@@ -226,7 +226,7 @@ commands =
 
 [testenv:flake8-examples]
 basepython = {[testenv:flake8]basepython}
-deps = {[testenv:flake8]deps} 
+deps = {[testenv:flake8]deps}
 commands =
     flake8 \
         # Ignore C901 complexity requirements (examples optimize for straightforward readability)
@@ -345,10 +345,10 @@ whitelist_externals = {[testenv:resetdocs]whitelist_externals}
 deps =
     -rdev_requirements/doc-requirements.txt
     -rdev_requirements/linter-requirements.txt
-commands = 
+commands =
     {[testenv:resetdocs]commands}
     doc8 doc/index.rst doc/lib/ README.rst CHANGELOG.rst
-    
+
 
 [testenv:readme]
 basepython = python3


### PR DESCRIPTION
We ([pyca/cryptography](https://github.com/pyca/cryptography)) run this project's test suite in our own CI  as part of our downstream testing. However, I noticed recently that while this project installs xdist, it doesn't use it. This PR fixes one small issue which caused xdist to fail and enables it across your test suite. This should allow us to drop our test times roughly in half for `cryptography`. Enjoy!

(Apologies for a few small extraneous whitespace fixes, my editor automatically does that)