### PR TITLE
fix(docs): Update AWS Doc URLs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -82,7 +82,7 @@ CachingMostRecentProvider replaces MostRecentProvider and provides a cache entry
 TTL to reauthorize the key with the key provider.
 
 MostRecentProvider is now deprecated, and is removed in 2.0.0. See
-https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/most-recent-provider.html
+https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/most-recent-provider.html#mrp-versions
 for more details.
 
 

--- a/README.rst
+++ b/README.rst
@@ -177,10 +177,10 @@ of the one that the client would normally construct for you.
     ... )  # this uses my_special_crypto_config
 
 
-.. _Amazon DynamoDB Encryption Client: https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/
+.. _Amazon DynamoDB Encryption Client: https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/legacy-dynamodb-encryption-client.html
 .. _Amazon DynamoDB: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html
-.. _primary documents: https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/
-.. _Concepts Guide: https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/concepts.html
+.. _primary documents: https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/legacy-dynamodb-encryption-client.html
+.. _Concepts Guide: https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/DDBEC-legacy-concepts.html
 .. _Amazon DynamoDB Encryption Client for Java: https://github.com/aws/aws-dynamodb-encryption-java/
 .. _Amazon DynamoDB Encryption Client for Python: https://github.com/aws/aws-dynamodb-encryption-python/
 .. _DynamoDB Stream: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -34,7 +34,7 @@ with this library.
 * `How to use raw symmetric wrapping keys <./src/dynamodb_encryption_sdk_examples/wrapped_symmetric_encrypted_table.py>`_
 * `How to use raw asymmetric wrapping keys <./src/dynamodb_encryption_sdk_examples/wrapped_rsa_encrypted_table.py>`_
 
-For more details on the different type of material providers, see `How to choose a cryptographic materials provider <https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/crypto-materials-providers.html>`_.
+For more details on the different type of material providers, see `How to choose a cryptographic materials provider <https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/crypto-materials-providers.html>`_.
 
 Running the examples
 ====================


### PR DESCRIPTION
*Issue #, if available:* As part of the new Database Encryption release, the docs for DDBEC-Python have moved. 

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

