### PR TITLE
chore(ci): skip pyenv installation if already exists

### DIFF
--- a/codebuild/python3.12.yml
+++ b/codebuild/python3.12.yml
@@ -15,7 +15,7 @@ phases:
   build:
     commands:
       - cd /root/.pyenv/plugins/python-build/../.. && git pull && cd -
-      - pyenv install 3.12.0
+      - pyenv install --skip-existing 3.12.0
       - pyenv local 3.12.0
       - pip install --upgrade pip
       - pip install setuptools


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- codebuild ci is failing with `pyenv 3.12.0 already exists`, with this change ci will skip `pyenv` installation if already exists

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

