### PR TITLE
fix(docs; gha): updated .readthedocs.yaml; macos-latest to macos-12

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -22,7 +22,7 @@ jobs:
           # x86 builds are only meaningful for Windows
           - os: windows-latest
             architecture: x86
-          - os: macos-latest
+          - os: macos-12
             architecture: x64
         python:
           - 3.8

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the doc/ directory with Sphinx
 sphinx:
    configuration: doc/conf.py
@@ -18,5 +24,5 @@ python:
   version: 3.8
   install:
     - requirements: dev_requirements/doc-requirements.txt
-    - method: setuptools
+    - method: pip
       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,6 @@ submodules:
   exclude: all
 
 python:
-  version: 3.8
   install:
     - requirements: dev_requirements/doc-requirements.txt
     - method: pip


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

