### PR TITLE
chore(CI): upgrade mac os version to macos-13 

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -22,7 +22,7 @@ jobs:
           # x86 builds are only meaningful for Windows
           - os: windows-latest
             architecture: x86
-          - os: macos-12
+          - os: macos-13
             architecture: x64
         python:
           - 3.8


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- macos12 is deprecated and CI will not run on masos12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

