### PR TITLE
fix: Bump setuptools to patch CVE-2024-6345

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,5 +8,6 @@ recursive-exclude doc .DS_Store *.pyc
 prune doc/build
 prune doc/lib/generated
 
+recursive-include dev_requirements *
 recursive-include test *
 recursive-exclude test .DS_Store *.pyc

--- a/dev_requirements/release-requirements.txt
+++ b/dev_requirements/release-requirements.txt
@@ -1,5 +1,6 @@
 pypi-parker==0.1.2
-setuptools==66.1.1
+setuptools>=75.0
+build>=1.0
 twine==3.8.0
 wheel==0.38.4
 #This is required for twine < 4.0

--- a/test/source-build-check.sh
+++ b/test/source-build-check.sh
@@ -12,13 +12,13 @@ echo "Using working directory ${WORKINGDIR}"
 echo "Using dist directory ${DISTDIR}"
 
 echo "Locating the source build and copying it into the working directory."
-DISTFILE=$(ls ${DISTDIR}/dynamodb-encryption-sdk-*.tar.gz | tail -1)
+DISTFILE=$(ls ${DISTDIR}/dynamodb?encryption?sdk-*.tar.gz | tail -1)
 echo "Found source build at ${DISTFILE}"
 cp ${DISTFILE} ${WORKINGDIR}
 
 echo "Extracting the source build."
 cd ${WORKINGDIR}
-NEWDISTFILE=$(ls dynamodb-encryption-sdk-*.tar.gz | tail -1)
+NEWDISTFILE=$(ls dynamodb?encryption?sdk-*.tar.gz | tail -1)
 echo "Using distfile ${NEWDISTFILE}"
 tar xzvf ${NEWDISTFILE}
 rm ${NEWDISTFILE}

--- a/tox.ini
+++ b/tox.ini
@@ -403,7 +403,7 @@ basepython = python3
 skip_install = true
 deps = -rdev_requirements/release-requirements.txt
 commands =
-    python setup.py sdist bdist_wheel
+    python -m build
 
 [testenv:release-base]
 basepython = python3


### PR DESCRIPTION
Replace setuptools==66.1.1 with setuptools>=75.0 to address CVE-2024-6345. Modernize build command from deprecated 'python setup.py sdist bdist_wheel' to 'python -m build', which requires the build package.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

